### PR TITLE
Adds optional method getWithEnvironmentSubstitution() 

### DIFF
--- a/database.iml
+++ b/database.iml
@@ -8,7 +8,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <excludeFolder url="file://$MODULE_DIR$/src/main/java/oracle" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -40,9 +39,6 @@
     <orderEntry type="library" scope="TEST" name="Maven: log4j:log4j:1.2.17" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.derby:derby:10.13.1.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: io.vertx:vertx-unit:3.4.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: com.oracle:ojdbc7:12.1.0.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: com.microsoft.sqlserver:sqljdbc4:4.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.hsqldb:hsqldb:2.4.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.postgresql:postgresql:42.1.4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.github.stefanbirkner:system-rules:1.18.0" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,12 @@
       <version>3.4.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.18.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/main/java/com/github/susom/database/ConfigFrom.java
+++ b/src/main/java/com/github/susom/database/ConfigFrom.java
@@ -102,4 +102,7 @@ public interface ConfigFrom extends Supplier<Config> {
   ConfigFrom addPrefix(String prefix);
 
   Config get();
+
+  Config getWithEnvironmentSubstitution();
+
 }

--- a/src/main/java/com/github/susom/database/ConfigFrom.java
+++ b/src/main/java/com/github/susom/database/ConfigFrom.java
@@ -101,8 +101,8 @@ public interface ConfigFrom extends Supplier<Config> {
 
   ConfigFrom addPrefix(String prefix);
 
-  Config get();
+  ConfigFrom substitutions(Config config);
 
-  Config getWithEnvironmentSubstitution();
+  Config get();
 
 }

--- a/src/test/java/com/github/susom/database/test/ConfigTest.java
+++ b/src/test/java/com/github/susom/database/test/ConfigTest.java
@@ -5,7 +5,9 @@ import java.io.FileWriter;
 import java.math.BigDecimal;
 import java.util.Properties;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import com.github.susom.database.Config;
 import com.github.susom.database.ConfigFrom;
@@ -18,6 +20,10 @@ import static org.junit.Assert.*;
  * @author garricko
  */
 public class ConfigTest {
+
+  @Rule
+  public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
   @Test
   public void testSystemProperties() throws Exception {
     System.setProperty("foo", "bar");
@@ -37,6 +43,20 @@ public class ConfigTest {
     Config config = ConfigFrom.firstOf().properties(properties).get();
 
     assertEquals("bar", config.getString("foo"));
+    assertNull(config.getString("unknown"));
+    assertEquals("default", config.getString("unknown", "default"));
+  }
+
+  @Test
+  public void testEnvironmentSubstitution() throws Exception {
+    environmentVariables.set("BAR", "baz");
+
+    Properties properties = new Properties();
+    properties.setProperty("foo", "${BAR}");
+
+    Config config = ConfigFrom.firstOf().properties(properties).getWithEnvironmentSubstitution();
+
+    assertEquals("baz", config.getString("foo"));
     assertNull(config.getString("unknown"));
     assertEquals("default", config.getString("unknown", "default"));
   }


### PR DESCRIPTION
Resolves environment variables found in the values of Config keys. 
Useful for enhancing properties files with Kubernetes secrets/services. eg:

database.properties:
```
database.url=jdbc:oracle:thin:@${ORACLE_DATABASE_SERVICE_HOST}:${ORACLE_DATABASE_SERVICE_PORT}:ORCLCDB
database.user=foo
database.password=bar
```

Where `${ORACLE_DATABASE_SERVICE_HOST}` is an environment variable set by a Kubernetes Service providing a dynamic Oracle endpoint. This avoids dependencies between application configuration and deployment configuration.
