### PR TITLE
Upgrade vertx version to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,8 +249,19 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.5.4</version>
+      <version>3.6.0</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
@@ -286,7 +297,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.5.4</version>
+      <version>3.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
@garricko 

This PR contains the following dependency updates.

- vertx version upgrade from 3.5.4 to 3.6.0.
- jackson-databind

We built the project using .travis.yml and it was successful.

Please find the following build logs links.

- database:
https://docs.google.com/document/d/1PGzgGxM42mZQKZiET0zFfZgpNQ4zTlxoJnXCzH7Jo0k/edit

- database-goodies:
https://docs.google.com/document/d/1SJDcltRLE0Num94ze6gjemkSv4JTNUpXi2a9D9Wfk8Q/edit
https://docs.google.com/document/d/1KzCKXN3f-krVzVVoufJHj-DPKvhSJi_Tomlh8Pg5vy4/edit

With the above updates, the source clear risk score is reduced from 56 to 0.

Please review the PR and let us know your feedback.