### PR TITLE
commitAndClose/rollbackAndClose should always close

### DIFF
--- a/src/main/java/com/github/susom/database/DatabaseProvider.java
+++ b/src/main/java/com/github/susom/database/DatabaseProvider.java
@@ -1066,8 +1066,8 @@ public final class DatabaseProvider implements Supplier<Database> {
       } catch (Exception e) {
         throw new DatabaseException("Unable to commit the transaction", e);
       }
-      close();
     }
+    close();
   }
 
   public void rollbackAndClose() {
@@ -1082,8 +1082,8 @@ public final class DatabaseProvider implements Supplier<Database> {
       } catch (Exception e) {
         log.error("Unable to rollback the transaction", e);
       }
-      close();
     }
+    close();
   }
 
   private void close() {


### PR DESCRIPTION
Pretty sure this is a bug, although minor.  Found it while experimenting with BigQuery support (no transactions).