### PR TITLE
ASQ-136 - Extend SUSOM Database API to support LocalDate type

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ there is also a configuration option to make the above code do exactly the same 
 `argDateNowPerApp()` so you can in effect control the database server time as well as that
 of the application server.
 
+#### Support for java.time.LocalDate
+
+There are use cases where a true database date is more appropriate than a timestamp, 
+e.g., for recording date of birth or other fields where time is not really relevant or 
+known. The LocalDate API is stored as a database Date, not a Timestamp, for modern
+databases that support a true date type; Oracle does not support a true date type, so it 
+has been implemented as a timestamp.
+
 #### Correct handling of java.math.BigDecimal
 
 Similarly BigDecimal tries to maintain scale in a more intuitive manner

--- a/README.md
+++ b/README.md
@@ -181,15 +181,33 @@ There are use cases where a true database date is more appropriate than a timest
 e.g., for recording date of birth or other fields where time is not really relevant or 
 known. The LocalDate API is stored as a database Date, not a Timestamp, for modern
 databases that support a true date type.
+
+LocalDate has been implemented and tested using ISO 8601 format YYYY-MM-DD.  There should be
+no time or timezone associated.
+
+Postgres and MS SQLServer have implemented a fully compliant LocalDate that is consistentently
+returned as java.sql.Date.   There are no known issues with these databases.
  
 Oracle does not support a true date type; the Oracle Date is actually implemented as a 
 timestamp.  Oracle supports LocalDate by using a time of midnight and a timezone of 0. 
+As a result, there are times when the database type returned have been timestamp. 
 
 HSQLDB also does not support a true date type - it's date implementation uses a timestamp of 
 0 (midnight), but has a bug that sets timezone. For this reason, if a date is stored from one 
 timezone (e.g., system default timezone), and a user attempts to query for that date from 
-another timezone, it may not find the value.  This bug is documented in more detail here:
-https://bugs.documentfoundation.org/show_bug.cgi?id=63566
+another timezone, it may not find the value.  For this reason, HSQLDB is not recommended for 
+LocalDate type data if you are working across time zones.
+
+To work around old database implementations of LocalDate as a Timestamp, when a timestamp is
+received, the scale attribute is examined.  A scale of 0 on a Timestamp is always associated 
+with a LocalDate across all tested DB implementations; true timestamps always have a non-zero scale.  
+When a scale of zero is found, it is handled as LocalDate.
+
+More information on specific implementations is available here: 
+* Derby: https://db.apache.org/derby/papers/JDBCImplementation.html#Derby+SQL+DATE
+* HSQLDB: http://www.h2database.com/html/datatypes.html
+  * known problem:http://www.h2database.com/html/datatypes.html
+* Oracle: https://docs.oracle.com/javase/8/docs/api/java/sql/Timestamp.html
 
 #### Correct handling of java.math.BigDecimal
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,16 @@ of the application server.
 There are use cases where a true database date is more appropriate than a timestamp, 
 e.g., for recording date of birth or other fields where time is not really relevant or 
 known. The LocalDate API is stored as a database Date, not a Timestamp, for modern
-databases that support a true date type; Oracle does not support a true date type, so it 
-has been implemented as a timestamp.
+databases that support a true date type.
+ 
+Oracle does not support a true date type; the Oracle Date is actually implemented as a 
+timestamp.  Oracle supports LocalDate by using a time of midnight and a timezone of 0. 
+
+HSQLDB also does not support a true date type - it's date implementation uses a timestamp of 
+0 (midnight), but has a bug that sets timezone. For this reason, if a date is stored from one 
+timezone (e.g., system default timezone), and a user attempts to query for that date from 
+another timezone, it may not find the value.  This bug is documented in more detail here:
+https://bugs.documentfoundation.org/show_bug.cgi?id=63566
 
 #### Correct handling of java.math.BigDecimal
 

--- a/database.iml
+++ b/database.iml
@@ -35,6 +35,7 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.easymock:easymock:3.4" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:2.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.10.19" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:slf4j-log4j12:1.7.25" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: log4j:log4j:1.2.17" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.derby:derby:10.13.1.1" level="project" />

--- a/demo/database-demo.iml
+++ b/demo/database-demo.iml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
@@ -9,30 +11,30 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="database" />
+    <orderEntry type="library" name="Maven: com.github.susom:database:3.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:3.0.2" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
-    <orderEntry type="library" name="Maven: io.vertx:vertx-core:3.4.2" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-common:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-buffer:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-transport:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-handler:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-handler-proxy:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-socks:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-http:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-http2:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-resolver:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-resolver-dns:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-dns:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.7.4" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.7.4" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.7.0" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-server:9.4.6.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.9.8" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.9.0" level="project" />
+    <orderEntry type="library" name="Maven: io.vertx:vertx-core:3.5.4" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-common:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-buffer:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-transport:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-handler:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-handler-proxy:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-socks:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-http:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-http2:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-resolver:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-resolver-dns:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-dns:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.9.6" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-server:9.4.17.v20190418" level="project" />
     <orderEntry type="library" name="Maven: javax.servlet:javax.servlet-api:3.1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-http:9.4.6.v20170531" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util:9.4.6.v20170531" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-io:9.4.6.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-http:9.4.17.v20190418" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util:9.4.17.v20190418" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-io:9.4.17.v20190418" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:checker-qual:2.1.14" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:checker:2.1.14" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:jdk8:2.1.14" level="project" />

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.github.susom</groupId>
       <artifactId>database</artifactId>
-      <version>3.0-SNAPSHOT</version>
+      <version>3.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.25</version>

--- a/src/main/java/com/github/susom/database/DebugSql.java
+++ b/src/main/java/com/github/susom/database/DebugSql.java
@@ -18,9 +18,6 @@ package com.github.susom.database;
 
 import java.io.InputStream;
 import java.io.Reader;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -96,12 +93,10 @@ public class DebugSql {
             }
           } else if (argToPrint instanceof StatementAdaptor.SqlNull || argToPrint == null) {
             buf.append("null");
-          } else if (argToPrint instanceof Date) {
-            if (isMidnight(argToPrint)) {
+          } else if (argToPrint instanceof java.sql.Timestamp) {
+            buf.append(options.flavor().dateAsSqlFunction((Date) argToPrint, options.calendarForTimestamps()));
+          } else if (argToPrint instanceof java.sql.Date) {
               buf.append(options.flavor().localDateAsSqlFunction((Date) argToPrint));
-            } else {
-              buf.append(options.flavor().dateAsSqlFunction((Date) argToPrint, options.calendarForTimestamps()));
-            }
           } else if (argToPrint instanceof Number) {
             buf.append(argToPrint);
           } else if (argToPrint instanceof Boolean) {
@@ -136,33 +131,6 @@ public class DebugSql {
       buf.append(batchSize);
       buf.append(')');
     }
-  }
-
-  private static LocalDateTime getLocalDateTime(Object o) {
-    LocalDateTime dateTime = null;
-
-    if (o instanceof java.sql.Timestamp) {
-      dateTime = ((java.sql.Timestamp) o).toLocalDateTime();
-    } else if (o instanceof java.sql.Date) {
-      dateTime = Instant.ofEpochMilli(((java.sql.Date) o).getTime()).atZone(ZoneId.systemDefault()).toLocalDateTime();
-    } else if (o instanceof java.util.Date) {
-      dateTime = ((java.util.Date) o).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-    }
-
-    return dateTime;
-  }
-
-  private static boolean isMidnight(Object o) {
-
-    LocalDateTime dateTime = getLocalDateTime(o);
-
-    if (dateTime != null) {
-      // Get start of day for whatever day we currently have
-      LocalDateTime startOfDay = dateTime.toLocalDate().atStartOfDay();
-      return startOfDay.equals(dateTime);  // If true, the date has time at midnight
-    }
-
-    return false;
   }
 
   private static String removeTabs(String s) {

--- a/src/main/java/com/github/susom/database/Flavor.java
+++ b/src/main/java/com/github/susom/database/Flavor.java
@@ -713,7 +713,7 @@ public enum Flavor {
 
     @Override
     public String localDateAsSqlFunction(Date date) {
-      return "DATE '" + date.toString()+"'";
+      return "'" + date.toString()+"'";
     }
 
     @Override

--- a/src/main/java/com/github/susom/database/Flavor.java
+++ b/src/main/java/com/github/susom/database/Flavor.java
@@ -35,6 +35,7 @@ public enum Flavor {
 
     @Override
     public String typeBoolean() {
+
       return "char(1)";
     }
 
@@ -84,7 +85,9 @@ public enum Flavor {
     }
 
     @Override
-    public String typeLocalDate() { return "date"; }
+    public String typeLocalDate() {
+      return "date";
+    }
 
     @Override
     public boolean useStringForClob() {
@@ -595,7 +598,9 @@ public enum Flavor {
     }
 
     @Override
-    public String typeLocalDate() { return "date"; }
+    public String typeLocalDate() {
+      return "date";
+    }
 
     @Override
     public boolean useStringForClob() {

--- a/src/main/java/com/github/susom/database/Flavor.java
+++ b/src/main/java/com/github/susom/database/Flavor.java
@@ -84,7 +84,7 @@ public enum Flavor {
     }
 
     @Override
-    public String typeDbDate() { return "date"; }
+    public String typeLocalDate() { return "date"; }
 
     @Override
     public boolean useStringForClob() {
@@ -190,7 +190,7 @@ public enum Flavor {
     }
 
     @Override
-    public String typeDbDate() {
+    public String typeLocalDate() {
       return "date";
     }
 
@@ -320,7 +320,7 @@ public enum Flavor {
     }
 
     @Override
-    public String typeDbDate() {
+    public String typeLocalDate() {
       return "date";
     }
 
@@ -468,7 +468,7 @@ public enum Flavor {
     }
 
     @Override
-    public String typeDbDate() {
+    public String typeLocalDate() {
       return "date";
     }
 
@@ -595,7 +595,7 @@ public enum Flavor {
     }
 
     @Override
-    public String typeDbDate() { return "date"; }
+    public String typeLocalDate() { return "date"; }
 
     @Override
     public boolean useStringForClob() {
@@ -687,7 +687,7 @@ public enum Flavor {
 
   public abstract String typeDate();
 
-  public abstract String typeDbDate();
+  public abstract String typeLocalDate();
 
   public abstract boolean useStringForClob();
 

--- a/src/main/java/com/github/susom/database/Flavor.java
+++ b/src/main/java/com/github/susom/database/Flavor.java
@@ -152,6 +152,11 @@ public enum Flavor {
     }
 
     @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "'" + date.toString() + "'";
+    }
+
+    @Override
     public String sequenceOptions() {
       return " as bigint";
     }
@@ -279,6 +284,11 @@ public enum Flavor {
       SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS000");
       dateFormat.setCalendar(calendar);
       return "cast('" + dateFormat.format(date) + "' as datetime2(3))";
+    }
+
+    @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "'" + date.toString() + "'";
     }
 
     @Override
@@ -410,6 +420,11 @@ public enum Flavor {
     }
 
     @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "to_date('" + date.toString() + "', 'yyyy-mm-dd')";
+    }
+
+    @Override
     public String sequenceOptions() {
       return "";
     }
@@ -535,6 +550,11 @@ public enum Flavor {
       SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS000");
       dateFormat.setCalendar(calendar);
       return "'" + dateFormat.format(date) + " GMT'::timestamp";
+    }
+
+    @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "'" + date.toString()+"'";
     }
 
     @Override
@@ -665,6 +685,11 @@ public enum Flavor {
     }
 
     @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "DATE '" + date.toString()+"'";
+    }
+
+    @Override
     public String sequenceOptions() {
       return " as bigint";
     }
@@ -726,6 +751,11 @@ public enum Flavor {
    * looks like "'1970-01-02 02:17:36.789000 GMT'::timestamp".
    */
   public abstract String dateAsSqlFunction(Date date, Calendar calendar);
+
+/**
+ * Return a SQL function representing the specified date without time.
+ */
+  public abstract String localDateAsSqlFunction(Date date);
 
   public abstract String sequenceOptions();
 

--- a/src/main/java/com/github/susom/database/Flavor.java
+++ b/src/main/java/com/github/susom/database/Flavor.java
@@ -84,6 +84,9 @@ public enum Flavor {
     }
 
     @Override
+    public String typeDbDate() { return "date"; }
+
+    @Override
     public boolean useStringForClob() {
       return false;
     }
@@ -184,6 +187,11 @@ public enum Flavor {
     @Override
     public String typeDate() {
       return "datetime2(3)";
+    }
+
+    @Override
+    public String typeDbDate() {
+      return "date";
     }
 
     @Override
@@ -309,6 +317,11 @@ public enum Flavor {
     @Override
     public String typeDate() {
       return "timestamp(3)";
+    }
+
+    @Override
+    public String typeDbDate() {
+      return "date";
     }
 
     @Override
@@ -455,6 +468,11 @@ public enum Flavor {
     }
 
     @Override
+    public String typeDbDate() {
+      return "date";
+    }
+
+    @Override
     public boolean useStringForClob() {
       return true;
     }
@@ -577,6 +595,9 @@ public enum Flavor {
     }
 
     @Override
+    public String typeDbDate() { return "date"; }
+
+    @Override
     public boolean useStringForClob() {
       return true;
     }
@@ -665,6 +686,8 @@ public enum Flavor {
   public abstract String typeBlob();
 
   public abstract String typeDate();
+
+  public abstract String typeDbDate();
 
   public abstract boolean useStringForClob();
 

--- a/src/main/java/com/github/susom/database/Row.java
+++ b/src/main/java/com/github/susom/database/Row.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.math.BigDecimal;
 import java.sql.ResultSetMetaData;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import javax.annotation.Nonnull;
@@ -446,14 +447,43 @@ public interface Row {
   Date getDateOrNull(String columnName);
 
   /**
-   * Return a real database Date, with no timestamp
+   * Retrieve column as LocalDate, .i.e, date with no time.
+   * @return LocalDate of the database column value
    */
   @Nullable
   LocalDate getLocalDateOrNull();
 
+  /**
+   * Get the Date field, with no timestamp
+   * @param columnOneBased column number starting at 1, not 0
+   * @return LocalDate of the column value
+   */
   @Nullable
   LocalDate getLocalDateOrNull(int columnOneBased);
 
+  /**
+   * Get the Date field, with no timestamp
+   * @param columnName column name to retrieve
+   * @return LocalDate of the column value
+   */
   @Nullable
   LocalDate getLocalDateOrNull(String columnName);
+
+  /**
+   * Given a column, get the value as a LocalDateTime (or null) without changing
+   * the column cursor.
+   *
+   * @param columnName column name to retrieve
+   * @return Column value as a LocalDateTime
+   */
+  @Nullable
+  LocalDateTime toDateOrNull(String columnName);
+
+  /**
+   * Check to see if a timestamp column has a time of midnight (start of day) or not.
+   *
+   * @param columnName a column name in the row of type java.sql.Timestamp
+   * @return true if the date is exactly at midnight
+   */
+  boolean isMidnight(String columnName);
 }

--- a/src/main/java/com/github/susom/database/Row.java
+++ b/src/main/java/com/github/susom/database/Row.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.sql.ResultSetMetaData;
+import java.time.LocalDate;
 import java.util.Date;
 
 import javax.annotation.Nonnull;
@@ -443,4 +444,16 @@ public interface Row {
 
   @Nullable
   Date getDateOrNull(String columnName);
+
+  /**
+   * Return a real database Date, with no timestamp
+   */
+  @Nullable
+  LocalDate getDbDateOrNull();
+
+  @Nullable
+  LocalDate getDbDateOrNull(int columnOneBased);
+
+  @Nullable
+  LocalDate getDbDateOrNull(String columnName);
 }

--- a/src/main/java/com/github/susom/database/Row.java
+++ b/src/main/java/com/github/susom/database/Row.java
@@ -470,16 +470,6 @@ public interface Row {
   LocalDate getLocalDateOrNull(String columnName);
 
   /**
-   * Given a column, get the value as a LocalDateTime (or null) without changing
-   * the column cursor.
-   *
-   * @param columnName column name to retrieve
-   * @return Column value as a LocalDateTime
-   */
-  @Nullable
-  LocalDateTime toDateOrNull(String columnName);
-
-  /**
    * Check to see if a timestamp column has a time of midnight (start of day) or not.
    *
    * @param columnName a column name in the row of type java.sql.Timestamp

--- a/src/main/java/com/github/susom/database/Row.java
+++ b/src/main/java/com/github/susom/database/Row.java
@@ -449,11 +449,11 @@ public interface Row {
    * Return a real database Date, with no timestamp
    */
   @Nullable
-  LocalDate getDbDateOrNull();
+  LocalDate getLocalDateOrNull();
 
   @Nullable
-  LocalDate getDbDateOrNull(int columnOneBased);
+  LocalDate getLocalDateOrNull(int columnOneBased);
 
   @Nullable
-  LocalDate getDbDateOrNull(String columnName);
+  LocalDate getLocalDateOrNull(String columnName);
 }

--- a/src/main/java/com/github/susom/database/Row.java
+++ b/src/main/java/com/github/susom/database/Row.java
@@ -468,12 +468,4 @@ public interface Row {
    */
   @Nullable
   LocalDate getLocalDateOrNull(String columnName);
-
-  /**
-   * Check to see if a timestamp column has a time of midnight (start of day) or not.
-   *
-   * @param columnName a column name in the row of type java.sql.Timestamp
-   * @return true if the date is exactly at midnight
-   */
-  boolean isMidnight(String columnName);
 }

--- a/src/main/java/com/github/susom/database/RowStub.java
+++ b/src/main/java/com/github/susom/database/RowStub.java
@@ -7,13 +7,10 @@ import java.io.StringReader;
 import java.math.BigDecimal;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.sql.Types;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -681,54 +678,6 @@ public class RowStub {
       public LocalDate getLocalDateOrNull(String columnName) {
         col = columnIndexByName(columnName) + 1;
         return toLocalDate(rows.get(row)[columnIndexByName(columnName)]);
-      }
-
-      /**
-       * Check to see if a timestamp column has a time of midnight (start of day) or not.
-       *
-       * @param columnName a column name in the row of type java.sql.Timestamp
-       * @return true if the date is exactly at midnight
-       */
-      @Override
-      public boolean isMidnight(String columnName) {
-        LocalDateTime dbDateTime = toLocalDateTimeOrNull(columnName);
-        if (dbDateTime != null) {
-          LocalDateTime startOfDay = dbDateTime.toLocalDate().atStartOfDay();
-          return startOfDay.equals(dbDateTime);  // If true, the date has time at midnight
-        }
-        return false;
-      }
-
-      /**
-       * Given a column name, get the value as a LocalDateTime (or null) without changing
-       * the column cursor so we can analyze it.  We use LocalDateTime because some DBs
-       * like Oracle treat dates as timestamps, and we want everything here.
-       *
-       * @param columnName column name to retrieve
-       * @return Column value as a java.util.date
-       */
-      private LocalDateTime toLocalDateTimeOrNull(String columnName) {
-
-        Object o = rows.get(row)[columnIndexByName(columnName)];
-        if (o instanceof String) {
-          return LocalDateTime.parse((String) o);
-        }
-
-        if (o instanceof LocalDate){
-          return ((LocalDate) o).atStartOfDay();
-        }
-
-        if (o instanceof Date) {
-          return ((Date) o).toInstant()
-            .atZone(ZoneId.systemDefault())
-            .toLocalDateTime();
-        }
-
-        if (o instanceof Timestamp) {
-          return ((Timestamp) o).toLocalDateTime();
-        }
-
-        return null;
       }
 
       private void requireColumnNames() {

--- a/src/main/java/com/github/susom/database/RowStub.java
+++ b/src/main/java/com/github/susom/database/RowStub.java
@@ -10,6 +10,8 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -641,6 +643,26 @@ public class RowStub {
         return toDate(rows.get(row)[columnIndexByName(columnName)]);
       }
 
+      @Nullable
+      @Override
+      public LocalDate getDbDateOrNull() {
+        return toDbDate(rows.get(row)[++col]);
+      }
+
+      @Nullable
+      @Override
+      public LocalDate getDbDateOrNull(int columnOneBased) {
+        col = columnOneBased;
+        return toDbDate(rows.get(row)[columnOneBased-1]);
+      }
+
+      @Nullable
+      @Override
+      public LocalDate getDbDateOrNull(String columnName) {
+        col = columnIndexByName(columnName) + 1;
+        return toDbDate(rows.get(row)[columnIndexByName(columnName)]);
+      }
+
       private void requireColumnNames() {
         if (columnNames == null) {
           throw new DatabaseException("Column names were not provided for this stub");
@@ -742,6 +764,17 @@ public class RowStub {
           throw new DatabaseException("Didn't understand date string: " + s);
         }
         return (Date) o;
+      }
+
+      private LocalDate toDbDate(Object o) {
+        if (o instanceof String) {
+          String s = (String) o;
+          if (s.length() == "yyyy-MM-dd".length()) {
+            return LocalDate.parse(s, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+          }
+          throw new DatabaseException("Didn't understand date string: " + s);
+        }
+        return (LocalDate) o;
       }
     };
   }

--- a/src/main/java/com/github/susom/database/RowStub.java
+++ b/src/main/java/com/github/susom/database/RowStub.java
@@ -645,22 +645,22 @@ public class RowStub {
 
       @Nullable
       @Override
-      public LocalDate getDbDateOrNull() {
-        return toDbDate(rows.get(row)[++col]);
+      public LocalDate getLocalDateOrNull() {
+        return toLocalDate(rows.get(row)[++col]);
       }
 
       @Nullable
       @Override
-      public LocalDate getDbDateOrNull(int columnOneBased) {
+      public LocalDate getLocalDateOrNull(int columnOneBased) {
         col = columnOneBased;
-        return toDbDate(rows.get(row)[columnOneBased-1]);
+        return toLocalDate(rows.get(row)[columnOneBased-1]);
       }
 
       @Nullable
       @Override
-      public LocalDate getDbDateOrNull(String columnName) {
+      public LocalDate getLocalDateOrNull(String columnName) {
         col = columnIndexByName(columnName) + 1;
-        return toDbDate(rows.get(row)[columnIndexByName(columnName)]);
+        return toLocalDate(rows.get(row)[columnIndexByName(columnName)]);
       }
 
       private void requireColumnNames() {
@@ -766,7 +766,7 @@ public class RowStub {
         return (Date) o;
       }
 
-      private LocalDate toDbDate(Object o) {
+      private LocalDate toLocalDate(Object o) {
         if (o instanceof String) {
           String s = (String) o;
           if (s.length() == "yyyy-MM-dd".length()) {

--- a/src/main/java/com/github/susom/database/RowStub.java
+++ b/src/main/java/com/github/susom/database/RowStub.java
@@ -719,13 +719,13 @@ public class RowStub {
         }
 
         if (o instanceof Date) {
-          ((Date) o).toInstant()
+          return ((Date) o).toInstant()
             .atZone(ZoneId.systemDefault())
             .toLocalDateTime();
         }
 
         if (o instanceof Timestamp) {
-          ((Timestamp) o).toLocalDateTime();
+          return ((Timestamp) o).toLocalDateTime();
         }
 
         return null;

--- a/src/main/java/com/github/susom/database/RowsAdaptor.java
+++ b/src/main/java/com/github/susom/database/RowsAdaptor.java
@@ -25,6 +25,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.Date;
 
 import javax.annotation.Nonnull;
@@ -684,6 +685,7 @@ class RowsAdaptor implements Rows {
     return getDateOrNull(column++);
   }
 
+  @Nullable
   @Override
   public Date getDateOrNull(int columnOneBased) {
     try {
@@ -694,6 +696,7 @@ class RowsAdaptor implements Rows {
     }
   }
 
+  @Nullable
   @Override
   public Date getDateOrNull(String columnName) {
     try {
@@ -703,6 +706,35 @@ class RowsAdaptor implements Rows {
       throw new DatabaseException(e);
     }
   }
+
+  @Nullable
+  @Override
+  public LocalDate getDbDateOrNull() {
+    return getDbDateOrNull(column++);
+  }
+
+  @Nullable
+  @Override
+  public LocalDate getDbDateOrNull(int columnOneBased) {
+    try {
+      column = columnOneBased + 1;
+      return toDbDate(rs, columnOneBased);
+    } catch (SQLException e) {
+      throw new DatabaseException(e);
+    }
+  }
+
+  @Nullable
+  @Override
+  public LocalDate getDbDateOrNull(String columnName) {
+    try {
+      column = rs.findColumn(columnName) + 1;
+      return toDbDate(rs, columnName);
+    } catch (SQLException e) {
+      throw new DatabaseException(e);
+    }
+  }
+
 
   /**
    * Make sure the Timestamp will return getTime() accurate to the millisecond
@@ -722,6 +754,16 @@ class RowsAdaptor implements Rows {
   private Date toDate(ResultSet rs, String col) throws SQLException {
     Timestamp val = rs.getTimestamp(col, options.calendarForTimestamps());
     return val == null ? null : timestampToDate(val);
+  }
+
+  private LocalDate toDbDate(ResultSet rs, int col) throws SQLException {
+    java.sql.Date val = rs.getDate(col);
+    return val == null ? null : val.toLocalDate();
+  }
+
+  private LocalDate toDbDate(ResultSet rs, String col) throws SQLException {
+    java.sql.Date val = rs.getDate(col);
+    return val == null ? null : val.toLocalDate();
   }
 
   private Boolean toBoolean(ResultSet rs, int col) throws SQLException {

--- a/src/main/java/com/github/susom/database/RowsAdaptor.java
+++ b/src/main/java/com/github/susom/database/RowsAdaptor.java
@@ -738,29 +738,33 @@ class RowsAdaptor implements Rows {
 
   /**
    * Check to see if a timestamp column has a time of midnight (start of day) or not.
+   * Start of day is the default for Oracle dates which are really timestamps.
    *
    * @param columnName a column name in the row of type java.sql.Timestamp
    * @return true if the date is exactly at midnight
    */
   @Override
   public boolean isMidnight(String columnName) {
-    LocalDateTime dbDateTime = toDateOrNull(columnName);
+    LocalDateTime dbDateTime = toLocalDateTimeOrNull(columnName);
     if (dbDateTime != null) {
+      // Get start of day for whatever day we currently have
       LocalDateTime startOfDay = dbDateTime.toLocalDate().atStartOfDay();
-      return startOfDay.equals(dbDateTime);  // If true, the date has time at midnight
+      return startOfDay.equals(dbDateTime);  // If true, the db date has time at midnight
     }
     return false;
   }
 
   /**
-   * Given a column name, get the value as a Date (or null) without changing the column cursor.
+   * Given a column name, get the value as a LocalDateTime (or null) without changing
+   * the column cursor so we can analyze it.  We use LocalDateTime because some DBs
+   * like Oracle treat dates as timestamps, and we want everything here.
    *
    * @param columnName column name to retrieve
    * @return Column value as a LocalDateTime
    */
-  @Nullable
-  @Override
-  public LocalDateTime toDateOrNull(String columnName) {
+  // @Nullable
+  // @Override
+  private LocalDateTime toLocalDateTimeOrNull(String columnName) {
     try {
       Timestamp val = rs.getTimestamp(columnName);
       return val == null ? null : val.toLocalDateTime();

--- a/src/main/java/com/github/susom/database/RowsAdaptor.java
+++ b/src/main/java/com/github/susom/database/RowsAdaptor.java
@@ -709,16 +709,16 @@ class RowsAdaptor implements Rows {
 
   @Nullable
   @Override
-  public LocalDate getDbDateOrNull() {
-    return getDbDateOrNull(column++);
+  public LocalDate getLocalDateOrNull() {
+    return getLocalDateOrNull(column++);
   }
 
   @Nullable
   @Override
-  public LocalDate getDbDateOrNull(int columnOneBased) {
+  public LocalDate getLocalDateOrNull(int columnOneBased) {
     try {
       column = columnOneBased + 1;
-      return toDbDate(rs, columnOneBased);
+      return toLocalDate(rs, columnOneBased);
     } catch (SQLException e) {
       throw new DatabaseException(e);
     }
@@ -726,10 +726,10 @@ class RowsAdaptor implements Rows {
 
   @Nullable
   @Override
-  public LocalDate getDbDateOrNull(String columnName) {
+  public LocalDate getLocalDateOrNull(String columnName) {
     try {
       column = rs.findColumn(columnName) + 1;
-      return toDbDate(rs, columnName);
+      return toLocalDate(rs, columnName);
     } catch (SQLException e) {
       throw new DatabaseException(e);
     }
@@ -756,12 +756,12 @@ class RowsAdaptor implements Rows {
     return val == null ? null : timestampToDate(val);
   }
 
-  private LocalDate toDbDate(ResultSet rs, int col) throws SQLException {
+  private LocalDate toLocalDate(ResultSet rs, int col) throws SQLException {
     java.sql.Date val = rs.getDate(col);
     return val == null ? null : val.toLocalDate();
   }
 
-  private LocalDate toDbDate(ResultSet rs, String col) throws SQLException {
+  private LocalDate toLocalDate(ResultSet rs, String col) throws SQLException {
     java.sql.Date val = rs.getDate(col);
     return val == null ? null : val.toLocalDate();
   }

--- a/src/main/java/com/github/susom/database/RowsAdaptor.java
+++ b/src/main/java/com/github/susom/database/RowsAdaptor.java
@@ -26,7 +26,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Date;
 
 import javax.annotation.Nonnull;
@@ -731,43 +730,6 @@ class RowsAdaptor implements Rows {
     try {
       column = rs.findColumn(columnName) + 1;
       return toLocalDate(rs, columnName);
-    } catch (SQLException e) {
-      throw new DatabaseException(e);
-    }
-  }
-
-  /**
-   * Check to see if a timestamp column has a time of midnight (start of day) or not.
-   * Start of day is the default for Oracle dates which are really timestamps.
-   *
-   * @param columnName a column name in the row of type java.sql.Timestamp
-   * @return true if the date is exactly at midnight
-   */
-  @Override
-  public boolean isMidnight(String columnName) {
-    LocalDateTime dbDateTime = toLocalDateTimeOrNull(columnName);
-    if (dbDateTime != null) {
-      // Get start of day for whatever day we currently have
-      LocalDateTime startOfDay = dbDateTime.toLocalDate().atStartOfDay();
-      return startOfDay.equals(dbDateTime);  // If true, the db date has time at midnight
-    }
-    return false;
-  }
-
-  /**
-   * Given a column name, get the value as a LocalDateTime (or null) without changing
-   * the column cursor so we can analyze it.  We use LocalDateTime because some DBs
-   * like Oracle treat dates as timestamps, and we want everything here.
-   *
-   * @param columnName column name to retrieve
-   * @return Column value as a LocalDateTime
-   */
-  // @Nullable
-  // @Override
-  private LocalDateTime toLocalDateTimeOrNull(String columnName) {
-    try {
-      Timestamp val = rs.getTimestamp(columnName);
-      return val == null ? null : val.toLocalDateTime();
     } catch (SQLException e) {
       throw new DatabaseException(e);
     }

--- a/src/main/java/com/github/susom/database/RowsAdaptor.java
+++ b/src/main/java/com/github/susom/database/RowsAdaptor.java
@@ -26,6 +26,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import javax.annotation.Nonnull;
@@ -735,6 +736,38 @@ class RowsAdaptor implements Rows {
     }
   }
 
+  /**
+   * Check to see if a timestamp column has a time of midnight (start of day) or not.
+   *
+   * @param columnName a column name in the row of type java.sql.Timestamp
+   * @return true if the date is exactly at midnight
+   */
+  @Override
+  public boolean isMidnight(String columnName) {
+    LocalDateTime dbDateTime = toDateOrNull(columnName);
+    if (dbDateTime != null) {
+      LocalDateTime startOfDay = dbDateTime.toLocalDate().atStartOfDay();
+      return startOfDay.equals(dbDateTime);  // If true, the date has time at midnight
+    }
+    return false;
+  }
+
+  /**
+   * Given a column name, get the value as a Date (or null) without changing the column cursor.
+   *
+   * @param columnName column name to retrieve
+   * @return Column value as a LocalDateTime
+   */
+  @Nullable
+  @Override
+  public LocalDateTime toDateOrNull(String columnName) {
+    try {
+      Timestamp val = rs.getTimestamp(columnName);
+      return val == null ? null : val.toLocalDateTime();
+    } catch (SQLException e) {
+      throw new DatabaseException(e);
+    }
+  }
 
   /**
    * Make sure the Timestamp will return getTime() accurate to the millisecond

--- a/src/main/java/com/github/susom/database/Schema.java
+++ b/src/main/java/com/github/susom/database/Schema.java
@@ -121,6 +121,12 @@ public class Schema {
           } else if (precision1 == 19 && scale == 0) {
             // Oracle reports long as numeric
             table.addColumn(names[i]).asLong();
+          } else if (precision1 == 126 && scale == -127) {
+            // this clause was added to support ETL from MSSQL Server
+            table.addColumn(names[i]).asFloat();
+          } else if (precision1 == 0 && scale == -127) {
+            // this clause was also added to support ETL from MSSQL Server
+            table.addColumn(names[i]).asInteger();
           } else {
             table.addColumn(names[i]).asBigDecimal(precision1, scale);
           }

--- a/src/main/java/com/github/susom/database/Schema.java
+++ b/src/main/java/com/github/susom/database/Schema.java
@@ -63,7 +63,7 @@ public class Schema {
   }
 
   public enum ColumnType {
-    Integer, Long, Float, Double, BigDecimal, StringVar, StringFixed, Clob, Blob, Date, DbDate, Boolean
+    Integer, Long, Float, Double, BigDecimal, StringVar, StringFixed, Clob, Blob, Date, LocalDate, Boolean
   }
 
   public void validate() {
@@ -144,7 +144,7 @@ public class Schema {
           table.addColumn(names[i]).asDate();
           break;
         case Types.DATE:
-            table.addColumn(names[i]).asDbDate();
+            table.addColumn(names[i]).asLocalDate();
             break;
         case Types.NVARCHAR:
         case Types.VARCHAR:
@@ -638,8 +638,8 @@ public class Schema {
         return asType(ColumnType.Date);
       }
 
-      public Column asDbDate() {
-        return asType(ColumnType.DbDate);
+      public Column asLocalDate() {
+        return asType(ColumnType.LocalDate);
       }
 
       public Column asClob() {
@@ -768,8 +768,8 @@ public class Schema {
           case Date:
             sql.append(flavor.typeDate());
             break;
-          case DbDate:
-            sql.append(flavor.typeDbDate());
+          case LocalDate:
+            sql.append(flavor.typeLocalDate());
             break;
           case Clob:
             sql.append(flavor.typeClob());

--- a/src/main/java/com/github/susom/database/Schema.java
+++ b/src/main/java/com/github/susom/database/Schema.java
@@ -146,8 +146,8 @@ public class Schema {
           break;
 
         // The date type is used for a true date - no time info.
-        // It must be processed before TimeStamp because dates are also
-        // recognized as timestamp type.
+        // It must be checked before TimeStamp because sql dates are also
+        // recognized as sql timestamp.
         case Types.DATE:
           table.addColumn(names[i]).asLocalDate();
           break;
@@ -788,10 +788,10 @@ public class Schema {
             sql.append(flavor.typeStringFixed(column.scale));
             break;
           case Date:
-            sql.append(flavor.typeDate());      // Append a date with timestamp
+            sql.append(flavor.typeDate());      // Append a date with time
             break;
           case LocalDate:
-            sql.append(flavor.typeLocalDate()); // Append a true date - no timestamp
+            sql.append(flavor.typeLocalDate()); // Append a true date - no time
             break;
           case Clob:
             sql.append(flavor.typeClob());

--- a/src/main/java/com/github/susom/database/Schema.java
+++ b/src/main/java/com/github/susom/database/Schema.java
@@ -63,7 +63,7 @@ public class Schema {
   }
 
   public enum ColumnType {
-    Integer, Long, Float, Double, BigDecimal, StringVar, StringFixed, Clob, Blob, Date, Boolean
+    Integer, Long, Float, Double, BigDecimal, StringVar, StringFixed, Clob, Blob, Date, DbDate, Boolean
   }
 
   public void validate() {
@@ -143,6 +143,9 @@ public class Schema {
         case Types.TIMESTAMP:
           table.addColumn(names[i]).asDate();
           break;
+        case Types.DATE:
+            table.addColumn(names[i]).asDbDate();
+            break;
         case Types.NVARCHAR:
         case Types.VARCHAR:
           int precision = metadata.getPrecision(i + 1);
@@ -635,6 +638,10 @@ public class Schema {
         return asType(ColumnType.Date);
       }
 
+      public Column asDbDate() {
+        return asType(ColumnType.DbDate);
+      }
+
       public Column asClob() {
         return asType(ColumnType.Clob);
       }
@@ -760,6 +767,9 @@ public class Schema {
             break;
           case Date:
             sql.append(flavor.typeDate());
+            break;
+          case DbDate:
+            sql.append(flavor.typeDbDate());
             break;
           case Clob:
             sql.append(flavor.typeClob());

--- a/src/main/java/com/github/susom/database/Schema.java
+++ b/src/main/java/com/github/susom/database/Schema.java
@@ -155,11 +155,10 @@ public class Schema {
         // This is the type dates and times with time and time zone associated.
         // Note that Oracle dates are always really Timestamps.
         case Types.TIMESTAMP:
-          // Old DBs like Oracle do not have a date type.  Date is implemented as a timestamp
-          // In this case, we will look to see if the time is exactly midnight down to nanosecond
-          // to determine if it is really a LocalDate.
-          if (r.isMidnight(names[i])) {
-            log.warn("Processing Oracle DB column "+names[i]+" as a LocalDate because time was 0");
+          // Check if we really have a LocalDate implemented by the DB as a timestamp
+          if (metadata.getScale(i + 1) == 0) {
+            // If the scale is 0, this is a LocalDate (no time/timezone).
+            // Anything with a time/timezone will have a non-zero scale
             table.addColumn(names[i]).asLocalDate();
           } else {
             table.addColumn(names[i]).asDate();

--- a/src/main/java/com/github/susom/database/SqlArgs.java
+++ b/src/main/java/com/github/susom/database/SqlArgs.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Apply {
   public enum ColumnType {
     Integer, Long, Float, Double, BigDecimal, String, ClobString, ClobStream,
-    BlobBytes, BlobStream, Date, DbDate, DateNowPerApp, DateNowPerDb, Boolean
+    BlobBytes, BlobStream, Date, LocalDate, DateNowPerApp, DateNowPerDb, Boolean
   }
 
   private static class Invocation {
@@ -176,14 +176,14 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
   }
 
   @Nonnull
-  public SqlArgs argDbDate(@Nullable LocalDate arg) {
-    invocations.add(new Invocation(ColumnType.DbDate, null, arg));
+  public SqlArgs argLocalDate(@Nullable LocalDate arg) {
+    invocations.add(new Invocation(ColumnType.LocalDate, null, arg));
     return this;
   }
 
   @Nonnull
-  public SqlArgs argDbDate(@Nonnull String argName, @Nullable LocalDate arg) {
-    invocations.add(new Invocation(ColumnType.DbDate, argName, arg));
+  public SqlArgs argLocalDate(@Nonnull String argName, @Nullable LocalDate arg) {
+    invocations.add(new Invocation(ColumnType.LocalDate, argName, arg));
     return this;
   }
 
@@ -376,6 +376,13 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
         throw new DatabaseException("Don't use Blob parameters with select statements");
       case BlobStream:
         throw new DatabaseException("Don't use Blob parameters with select statements");
+      case LocalDate:
+        if (i.argName == null) {
+          select.argLocalDate((LocalDate) i.arg);
+        } else {
+          select.argLocalDate(i.argName, (LocalDate) i.arg);
+        }
+        break;
       case Date:
         if (i.argName == null) {
           select.argDate((Date) i.arg);
@@ -490,11 +497,11 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
           insert.argDate(i.argName, (Date) i.arg);
         }
         break;
-      case DbDate:
+      case LocalDate:
         if (i.argName == null) {
-          insert.argDbDate((LocalDate) i.arg);
+          insert.argLocalDate((LocalDate) i.arg);
         } else {
-          insert.argDbDate(i.argName, (LocalDate) i.arg);
+          insert.argLocalDate(i.argName, (LocalDate) i.arg);
         }
         break;
       case DateNowPerApp:
@@ -597,6 +604,13 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
           update.argBlobStream(i.argName, (InputStream) i.arg);
         }
         break;
+      case LocalDate:
+        if (i.argName == null) {
+          update.argLocalDate((LocalDate) i.arg);
+        } else {
+          update.argLocalDate(i.argName, (LocalDate) i.arg);
+        }
+       break;
       case Date:
         if (i.argName == null) {
           update.argDate((Date) i.arg);
@@ -692,7 +706,7 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
           args.argClobString(names[i], r.getClobStringOrNull());
           break;
         case Types.DATE:
-            args.argDbDate(names[i], r.getDbDateOrNull());
+            args.argLocalDate(names[i], r.getLocalDateOrNull());
             break;
         case Types.TIMESTAMP:
           args.argDate(names[i], r.getDateOrNull());

--- a/src/main/java/com/github/susom/database/SqlArgs.java
+++ b/src/main/java/com/github/susom/database/SqlArgs.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedHashSet;
@@ -41,7 +42,7 @@ import javax.annotation.Nullable;
 public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Apply {
   public enum ColumnType {
     Integer, Long, Float, Double, BigDecimal, String, ClobString, ClobStream,
-    BlobBytes, BlobStream, Date, DateNowPerApp, DateNowPerDb, Boolean
+    BlobBytes, BlobStream, Date, DbDate, DateNowPerApp, DateNowPerDb, Boolean
   }
 
   private static class Invocation {
@@ -171,6 +172,18 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
   @Nonnull
   public SqlArgs argDate(@Nonnull String argName, @Nullable Date arg) {
     invocations.add(new Invocation(ColumnType.Date, argName, arg));
+    return this;
+  }
+
+  @Nonnull
+  public SqlArgs argDbDate(@Nullable LocalDate arg) {
+    invocations.add(new Invocation(ColumnType.DbDate, null, arg));
+    return this;
+  }
+
+  @Nonnull
+  public SqlArgs argDbDate(@Nonnull String argName, @Nullable LocalDate arg) {
+    invocations.add(new Invocation(ColumnType.DbDate, argName, arg));
     return this;
   }
 
@@ -477,6 +490,13 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
           insert.argDate(i.argName, (Date) i.arg);
         }
         break;
+      case DbDate:
+        if (i.argName == null) {
+          insert.argDbDate((LocalDate) i.arg);
+        } else {
+          insert.argDbDate(i.argName, (LocalDate) i.arg);
+        }
+        break;
       case DateNowPerApp:
         if (i.argName == null) {
           insert.argDateNowPerApp();
@@ -671,6 +691,9 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
         case Types.NCLOB:
           args.argClobString(names[i], r.getClobStringOrNull());
           break;
+        case Types.DATE:
+            args.argDbDate(names[i], r.getDbDateOrNull());
+            break;
         case Types.TIMESTAMP:
           args.argDate(names[i], r.getDateOrNull());
           break;

--- a/src/main/java/com/github/susom/database/SqlArgs.java
+++ b/src/main/java/com/github/susom/database/SqlArgs.java
@@ -170,28 +170,28 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
 
   @Nonnull
   public SqlArgs argDate(@Nullable Date arg) {
-    // date argument with a timestamp on it
+    // date argument with a time on it
     invocations.add(new Invocation(ColumnType.Date, null, arg));
     return this;
   }
 
   @Nonnull
   public SqlArgs argDate(@Nonnull String argName, @Nullable Date arg) {
-    // date argument with a timestamp on it
+    // date argument with a time on it
     invocations.add(new Invocation(ColumnType.Date, argName, arg));
     return this;
   }
 
   @Nonnull
   public SqlArgs argLocalDate(@Nullable LocalDate arg) {
-    // date argument with no timestamp on it
+    // date argument with no time on it
     invocations.add(new Invocation(ColumnType.LocalDate, null, arg));
     return this;
   }
 
   @Nonnull
   public SqlArgs argLocalDate(@Nonnull String argName, @Nullable LocalDate arg) {
-    // date argument with no timestamp on it
+    // date argument with no time on it
     invocations.add(new Invocation(ColumnType.LocalDate, argName, arg));
     return this;
   }
@@ -386,7 +386,7 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
       case BlobStream:
         throw new DatabaseException("Don't use Blob parameters with select statements");
       case LocalDate:
-        // date argument with no timestamp on it
+        // date argument with no time on it
         if (i.argName == null) {
           select.argLocalDate((LocalDate) i.arg);
         } else {
@@ -394,7 +394,7 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
         }
         break;
       case Date:
-        // date argument with a timestamp on it
+        // date argument with a time on it
         if (i.argName == null) {
           select.argDate((Date) i.arg);
         } else {
@@ -502,7 +502,7 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
         }
         break;
       case Date:
-        // date argument with a timestamp on it
+        // date argument with a time on it
         if (i.argName == null) {
           insert.argDate((Date) i.arg);
         } else {
@@ -510,7 +510,7 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
         }
         break;
       case LocalDate:
-        // date argument with no timestamp on it
+        // date argument with no time on it
         if (i.argName == null) {
           insert.argLocalDate((LocalDate) i.arg);
         } else {
@@ -618,7 +618,7 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
         }
         break;
       case LocalDate:
-        // date argument with no timestamp on it
+        // date argument with no time on it
         if (i.argName == null) {
           update.argLocalDate((LocalDate) i.arg);
         } else {
@@ -626,7 +626,7 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
         }
        break;
       case Date:
-        // date argument with a timestamp on it
+        // date argument with a time on it
         if (i.argName == null) {
           update.argDate((Date) i.arg);
         } else {
@@ -721,7 +721,7 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
           args.argClobString(names[i], r.getClobStringOrNull());
           break;
 
-        // Process Date before TimeStamp since dates are also timestamps
+        // Check Date before TimeStamp because SQL dates are also timestamps
         case Types.DATE:
             args.argLocalDate(names[i], r.getLocalDateOrNull());
             break;

--- a/src/main/java/com/github/susom/database/SqlArgs.java
+++ b/src/main/java/com/github/susom/database/SqlArgs.java
@@ -501,20 +501,20 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
           insert.argBlobStream(i.argName, (InputStream) i.arg);
         }
         break;
+        case LocalDate:
+          // date argument with no time on it
+          if (i.argName == null) {
+            insert.argLocalDate((LocalDate) i.arg);
+          } else {
+            insert.argLocalDate(i.argName, (LocalDate) i.arg);
+          }
+          break;
       case Date:
         // date argument with a time on it
         if (i.argName == null) {
           insert.argDate((Date) i.arg);
         } else {
           insert.argDate(i.argName, (Date) i.arg);
-        }
-        break;
-      case LocalDate:
-        // date argument with no time on it
-        if (i.argName == null) {
-          insert.argLocalDate((LocalDate) i.arg);
-        } else {
-          insert.argLocalDate(i.argName, (LocalDate) i.arg);
         }
         break;
       case DateNowPerApp:
@@ -727,8 +727,9 @@ public class SqlArgs implements SqlInsert.Apply, SqlUpdate.Apply, SqlSelect.Appl
             break;
 
         case Types.TIMESTAMP:
-          if (r.isMidnight(names[i])) {
-            log.warn("Processing Oracle DB column " + names[i] + " as a LocalDate because time was 0");
+          if (this.scale[i] == 0) {
+            // If the scale is 0, this is a LocalDate (no time/timezone).
+            // Anything with a time will have a non-zero scale
             args.argLocalDate(names[i], r.getLocalDateOrNull());
           } else {
             args.argDate(names[i], r.getDateOrNull());

--- a/src/main/java/com/github/susom/database/SqlInsert.java
+++ b/src/main/java/com/github/susom/database/SqlInsert.java
@@ -89,19 +89,19 @@ public interface SqlInsert {
 
   @Nonnull
   @CheckReturnValue
-  SqlInsert argDate(Date arg);
+  SqlInsert argDate(Date arg); // date with time
 
   @Nonnull
   @CheckReturnValue
-  SqlInsert argDate(@Nonnull String argName, Date arg);
+  SqlInsert argDate(@Nonnull String argName, Date arg); // date with time
 
   @Nonnull
   @CheckReturnValue
-  SqlInsert argLocalDate(LocalDate arg);
+  SqlInsert argLocalDate(LocalDate arg); // date only - no timestamp
 
   @Nonnull
   @CheckReturnValue
-  SqlInsert argLocalDate(@Nonnull String argName, LocalDate arg);
+  SqlInsert argLocalDate(@Nonnull String argName, LocalDate arg);  // date only - no timestamp
 
   @Nonnull
   @CheckReturnValue

--- a/src/main/java/com/github/susom/database/SqlInsert.java
+++ b/src/main/java/com/github/susom/database/SqlInsert.java
@@ -97,11 +97,11 @@ public interface SqlInsert {
 
   @Nonnull
   @CheckReturnValue
-  SqlInsert argDbDate(LocalDate arg);
+  SqlInsert argLocalDate(LocalDate arg);
 
   @Nonnull
   @CheckReturnValue
-  SqlInsert argDbDate(@Nonnull String argName, LocalDate arg);
+  SqlInsert argLocalDate(@Nonnull String argName, LocalDate arg);
 
   @Nonnull
   @CheckReturnValue

--- a/src/main/java/com/github/susom/database/SqlInsert.java
+++ b/src/main/java/com/github/susom/database/SqlInsert.java
@@ -19,6 +19,7 @@ package com.github.susom.database;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Date;
 
 import javax.annotation.CheckReturnValue;
@@ -93,6 +94,14 @@ public interface SqlInsert {
   @Nonnull
   @CheckReturnValue
   SqlInsert argDate(@Nonnull String argName, Date arg);
+
+  @Nonnull
+  @CheckReturnValue
+  SqlInsert argDbDate(LocalDate arg);
+
+  @Nonnull
+  @CheckReturnValue
+  SqlInsert argDbDate(@Nonnull String argName, LocalDate arg);
 
   @Nonnull
   @CheckReturnValue

--- a/src/main/java/com/github/susom/database/SqlInsertImpl.java
+++ b/src/main/java/com/github/susom/database/SqlInsertImpl.java
@@ -165,12 +165,12 @@ public class SqlInsertImpl implements SqlInsert {
 
   @Override
   @Nonnull
-  public SqlInsert argDbDate(@Nonnull String argName, LocalDate arg) { return namedArg(argName, adaptor.nullDbDate(arg)); }
+  public SqlInsert argLocalDate(@Nonnull String argName, LocalDate arg) { return namedArg(argName, adaptor.nullLocalDate(arg)); }
 
   @Override
   @Nonnull
-  public SqlInsert argDbDate(LocalDate arg) {
-    return positionalArg(adaptor.nullDbDate(arg));
+  public SqlInsert argLocalDate(LocalDate arg) {
+    return positionalArg(adaptor.nullLocalDate(arg));
   }
 
   @Nonnull

--- a/src/main/java/com/github/susom/database/SqlInsertImpl.java
+++ b/src/main/java/com/github/susom/database/SqlInsertImpl.java
@@ -165,7 +165,9 @@ public class SqlInsertImpl implements SqlInsert {
 
   @Override
   @Nonnull
-  public SqlInsert argLocalDate(@Nonnull String argName, LocalDate arg) { return namedArg(argName, adaptor.nullLocalDate(arg)); }
+  public SqlInsert argLocalDate(@Nonnull String argName, LocalDate arg) {
+    return namedArg(argName, adaptor.nullLocalDate(arg));
+  }
 
   @Override
   @Nonnull

--- a/src/main/java/com/github/susom/database/SqlInsertImpl.java
+++ b/src/main/java/com/github/susom/database/SqlInsertImpl.java
@@ -24,6 +24,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -160,6 +161,16 @@ public class SqlInsertImpl implements SqlInsert {
   @Nonnull
   public SqlInsert argDate(@Nonnull String argName, Date arg) {
     return namedArg(argName, adaptor.nullDate(arg));
+  }
+
+  @Override
+  @Nonnull
+  public SqlInsert argDbDate(@Nonnull String argName, LocalDate arg) { return namedArg(argName, adaptor.nullDbDate(arg)); }
+
+  @Override
+  @Nonnull
+  public SqlInsert argDbDate(LocalDate arg) {
+    return positionalArg(adaptor.nullDbDate(arg));
   }
 
   @Nonnull

--- a/src/main/java/com/github/susom/database/SqlSelect.java
+++ b/src/main/java/com/github/susom/database/SqlSelect.java
@@ -97,11 +97,11 @@ public interface SqlSelect {
 
   @Nonnull
   @CheckReturnValue
-  SqlSelect argDbDate(LocalDate arg);
+  SqlSelect argLocalDate(LocalDate arg);
 
   @Nonnull
   @CheckReturnValue
-  SqlSelect argDbDate(@Nonnull String argName, LocalDate arg);
+  SqlSelect argLocalDate(@Nonnull String argName, LocalDate arg);
 
   @Nonnull
   @CheckReturnValue
@@ -241,11 +241,11 @@ public interface SqlSelect {
 
   @Nullable
   @CheckReturnValue
-  LocalDate queryDbDateOrNull();
+  LocalDate queryLocalDateOrNull();
 
   @Nonnull
   @CheckReturnValue
-  List<LocalDate> queryDbDates();
+  List<LocalDate> queryLocalDates();
 
   /**
    * This is the most generic and low-level way to iterate the query results.

--- a/src/main/java/com/github/susom/database/SqlSelect.java
+++ b/src/main/java/com/github/susom/database/SqlSelect.java
@@ -17,6 +17,7 @@
 package com.github.susom.database;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 
@@ -93,6 +94,14 @@ public interface SqlSelect {
   @Nonnull
   @CheckReturnValue
   SqlSelect argDate(@Nonnull String argName, Date arg);
+
+  @Nonnull
+  @CheckReturnValue
+  SqlSelect argDbDate(LocalDate arg);
+
+  @Nonnull
+  @CheckReturnValue
+  SqlSelect argDbDate(@Nonnull String argName, LocalDate arg);
 
   @Nonnull
   @CheckReturnValue
@@ -229,6 +238,14 @@ public interface SqlSelect {
   @Nonnull
   @CheckReturnValue
   List<Date> queryDates();
+
+  @Nullable
+  @CheckReturnValue
+  LocalDate queryDbDateOrNull();
+
+  @Nonnull
+  @CheckReturnValue
+  List<LocalDate> queryDbDates();
 
   /**
    * This is the most generic and low-level way to iterate the query results.

--- a/src/main/java/com/github/susom/database/SqlSelect.java
+++ b/src/main/java/com/github/susom/database/SqlSelect.java
@@ -89,19 +89,19 @@ public interface SqlSelect {
 
   @Nonnull
   @CheckReturnValue
-  SqlSelect argDate(Date arg);
+  SqlSelect argDate(Date arg);  // Date with time
 
   @Nonnull
   @CheckReturnValue
-  SqlSelect argDate(@Nonnull String argName, Date arg);
+  SqlSelect argDate(@Nonnull String argName, Date arg);  // Date with time
 
   @Nonnull
   @CheckReturnValue
-  SqlSelect argLocalDate(LocalDate arg);
+  SqlSelect argLocalDate(LocalDate arg); // Date without time
 
   @Nonnull
   @CheckReturnValue
-  SqlSelect argLocalDate(@Nonnull String argName, LocalDate arg);
+  SqlSelect argLocalDate(@Nonnull String argName, LocalDate arg); // Date without time
 
   @Nonnull
   @CheckReturnValue
@@ -233,19 +233,19 @@ public interface SqlSelect {
 
   @Nullable
   @CheckReturnValue
-  Date queryDateOrNull();
+  Date queryDateOrNull();  // Date with time
 
   @Nonnull
   @CheckReturnValue
-  List<Date> queryDates();
+  List<Date> queryDates();  // Date with time
 
   @Nullable
   @CheckReturnValue
-  LocalDate queryLocalDateOrNull();
+  LocalDate queryLocalDateOrNull();  // Date without time
 
   @Nonnull
   @CheckReturnValue
-  List<LocalDate> queryLocalDates();
+  List<LocalDate> queryLocalDates();  // Date without time
 
   /**
    * This is the most generic and low-level way to iterate the query results.

--- a/src/main/java/com/github/susom/database/SqlSelectImpl.java
+++ b/src/main/java/com/github/susom/database/SqlSelectImpl.java
@@ -151,24 +151,28 @@ public class SqlSelectImpl implements SqlSelect {
   @Nonnull
   @Override
   public SqlSelect argDate(Date arg) {
+    // Date with time
     return positionalArg(adaptor.nullDate(arg));
   }
 
   @Nonnull
   @Override
   public SqlSelect argDate(@Nonnull String argName, Date arg) {
+    // Date with time
     return namedArg(argName, adaptor.nullDate(arg));
   }
 
   @Nonnull
   @Override
   public SqlSelect argLocalDate(LocalDate arg) {
+    // Date with no time
     return positionalArg(adaptor.nullLocalDate(arg));
   }
 
   @Nonnull
   @Override
   public SqlSelect argLocalDate(@Nonnull String argName, LocalDate arg) {
+    // Date with no time
     return namedArg(argName, adaptor.nullLocalDate(arg));
   }
 
@@ -568,6 +572,7 @@ public class SqlSelectImpl implements SqlSelect {
   @Nullable
   @Override
   public LocalDate queryLocalDateOrNull() {
+    // Date without time
     return queryWithTimeout(new RowsHandler<LocalDate>() {
       @Override
       public LocalDate process(Rows rs) throws Exception {
@@ -582,6 +587,7 @@ public class SqlSelectImpl implements SqlSelect {
   @Nonnull
   @Override
   public List<LocalDate> queryLocalDates() {
+    // Date without time
     return queryWithTimeout(new RowsHandler<List<LocalDate>>() {
       @Override
       public List<LocalDate> process(Rows rs) throws Exception {

--- a/src/main/java/com/github/susom/database/SqlSelectImpl.java
+++ b/src/main/java/com/github/susom/database/SqlSelectImpl.java
@@ -162,14 +162,14 @@ public class SqlSelectImpl implements SqlSelect {
 
   @Nonnull
   @Override
-  public SqlSelect argDbDate(LocalDate arg) {
-    return positionalArg(adaptor.nullDbDate(arg));
+  public SqlSelect argLocalDate(LocalDate arg) {
+    return positionalArg(adaptor.nullLocalDate(arg));
   }
 
   @Nonnull
   @Override
-  public SqlSelect argDbDate(@Nonnull String argName, LocalDate arg) {
-    return namedArg(argName, adaptor.nullDbDate(arg));
+  public SqlSelect argLocalDate(@Nonnull String argName, LocalDate arg) {
+    return namedArg(argName, adaptor.nullLocalDate(arg));
   }
 
   @Nonnull
@@ -567,12 +567,12 @@ public class SqlSelectImpl implements SqlSelect {
 
   @Nullable
   @Override
-  public LocalDate queryDbDateOrNull() {
+  public LocalDate queryLocalDateOrNull() {
     return queryWithTimeout(new RowsHandler<LocalDate>() {
       @Override
       public LocalDate process(Rows rs) throws Exception {
         if (rs.next()) {
-          return rs.getDbDateOrNull(1);
+          return rs.getLocalDateOrNull(1);
         }
         return null;
       }
@@ -581,13 +581,13 @@ public class SqlSelectImpl implements SqlSelect {
 
   @Nonnull
   @Override
-  public List<LocalDate> queryDbDates() {
+  public List<LocalDate> queryLocalDates() {
     return queryWithTimeout(new RowsHandler<List<LocalDate>>() {
       @Override
       public List<LocalDate> process(Rows rs) throws Exception {
         List<LocalDate> result = new ArrayList<>();
         while (rs.next()) {
-          LocalDate value = rs.getDbDateOrNull(1);
+          LocalDate value = rs.getLocalDateOrNull(1);
           if (value != null) {
             result.add(value);
           }

--- a/src/main/java/com/github/susom/database/SqlSelectImpl.java
+++ b/src/main/java/com/github/susom/database/SqlSelectImpl.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -157,6 +158,18 @@ public class SqlSelectImpl implements SqlSelect {
   @Override
   public SqlSelect argDate(@Nonnull String argName, Date arg) {
     return namedArg(argName, adaptor.nullDate(arg));
+  }
+
+  @Nonnull
+  @Override
+  public SqlSelect argDbDate(LocalDate arg) {
+    return positionalArg(adaptor.nullDbDate(arg));
+  }
+
+  @Nonnull
+  @Override
+  public SqlSelect argDbDate(@Nonnull String argName, LocalDate arg) {
+    return namedArg(argName, adaptor.nullDbDate(arg));
   }
 
   @Nonnull
@@ -543,6 +556,38 @@ public class SqlSelectImpl implements SqlSelect {
         List<Date> result = new ArrayList<>();
         while (rs.next()) {
           Date value = rs.getDateOrNull(1);
+          if (value != null) {
+            result.add(value);
+          }
+        }
+        return result;
+      }
+    });
+  }
+
+  @Nullable
+  @Override
+  public LocalDate queryDbDateOrNull() {
+    return queryWithTimeout(new RowsHandler<LocalDate>() {
+      @Override
+      public LocalDate process(Rows rs) throws Exception {
+        if (rs.next()) {
+          return rs.getDbDateOrNull(1);
+        }
+        return null;
+      }
+    });
+  }
+
+  @Nonnull
+  @Override
+  public List<LocalDate> queryDbDates() {
+    return queryWithTimeout(new RowsHandler<List<LocalDate>>() {
+      @Override
+      public List<LocalDate> process(Rows rs) throws Exception {
+        List<LocalDate> result = new ArrayList<>();
+        while (rs.next()) {
+          LocalDate value = rs.getDbDateOrNull(1);
           if (value != null) {
             result.add(value);
           }

--- a/src/main/java/com/github/susom/database/SqlUpdate.java
+++ b/src/main/java/com/github/susom/database/SqlUpdate.java
@@ -98,11 +98,11 @@ public interface SqlUpdate {
 
   @Nonnull
   @CheckReturnValue
-  SqlUpdate argDbDate(@Nullable LocalDate arg);
+  SqlUpdate argLocalDate(@Nullable LocalDate arg);
 
   @Nonnull
   @CheckReturnValue
-  SqlUpdate argDbDate(@Nonnull String argName, @Nullable LocalDate arg);
+  SqlUpdate argLocalDate(@Nonnull String argName, @Nullable LocalDate arg);
 
   @Nonnull
   @CheckReturnValue

--- a/src/main/java/com/github/susom/database/SqlUpdate.java
+++ b/src/main/java/com/github/susom/database/SqlUpdate.java
@@ -19,6 +19,7 @@ package com.github.susom.database;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Date;
 
 import javax.annotation.CheckReturnValue;
@@ -94,6 +95,14 @@ public interface SqlUpdate {
   @Nonnull
   @CheckReturnValue
   SqlUpdate argDate(@Nonnull String argName, @Nullable Date arg);
+
+  @Nonnull
+  @CheckReturnValue
+  SqlUpdate argDbDate(@Nullable LocalDate arg);
+
+  @Nonnull
+  @CheckReturnValue
+  SqlUpdate argDbDate(@Nonnull String argName, @Nullable LocalDate arg);
 
   @Nonnull
   @CheckReturnValue

--- a/src/main/java/com/github/susom/database/SqlUpdate.java
+++ b/src/main/java/com/github/susom/database/SqlUpdate.java
@@ -90,19 +90,19 @@ public interface SqlUpdate {
 
   @Nonnull
   @CheckReturnValue
-  SqlUpdate argDate(@Nullable Date arg);
+  SqlUpdate argDate(@Nullable Date arg);  // Date with timestamp
 
   @Nonnull
   @CheckReturnValue
-  SqlUpdate argDate(@Nonnull String argName, @Nullable Date arg);
+  SqlUpdate argDate(@Nonnull String argName, @Nullable Date arg); // Date with timestamp
 
   @Nonnull
   @CheckReturnValue
-  SqlUpdate argLocalDate(@Nullable LocalDate arg);
+  SqlUpdate argLocalDate(@Nullable LocalDate arg);  // Date only - no timestamp
 
   @Nonnull
   @CheckReturnValue
-  SqlUpdate argLocalDate(@Nonnull String argName, @Nullable LocalDate arg);
+  SqlUpdate argLocalDate(@Nonnull String argName, @Nullable LocalDate arg); // Date only - no timestamp
 
   @Nonnull
   @CheckReturnValue

--- a/src/main/java/com/github/susom/database/SqlUpdateImpl.java
+++ b/src/main/java/com/github/susom/database/SqlUpdateImpl.java
@@ -147,24 +147,28 @@ public class SqlUpdateImpl implements SqlUpdate {
   @Override
   @Nonnull
   public SqlUpdate argDate(@Nullable Date arg) {
+    // Date with time
     return positionalArg(adaptor.nullDate(arg));
   }
 
   @Override
   @Nonnull
   public SqlUpdate argDate(@Nonnull String argName, @Nullable Date arg) {
+    // Date with time
     return namedArg(argName, adaptor.nullDate(arg));
   }
 
   @Override
   @Nonnull
   public SqlUpdate argLocalDate(@Nullable LocalDate arg) {
+    // Date with no time
     return positionalArg(adaptor.nullLocalDate(arg));
   }
 
   @Override
   @Nonnull
   public SqlUpdate argLocalDate(@Nonnull String argName, @Nullable LocalDate arg) {
+    // Date with no time
     return namedArg(argName, adaptor.nullLocalDate(arg));
   }
 

--- a/src/main/java/com/github/susom/database/SqlUpdateImpl.java
+++ b/src/main/java/com/github/susom/database/SqlUpdateImpl.java
@@ -158,14 +158,14 @@ public class SqlUpdateImpl implements SqlUpdate {
 
   @Override
   @Nonnull
-  public SqlUpdate argDbDate(@Nullable LocalDate arg) {
-    return positionalArg(adaptor.nullDbDate(arg));
+  public SqlUpdate argLocalDate(@Nullable LocalDate arg) {
+    return positionalArg(adaptor.nullLocalDate(arg));
   }
 
   @Override
   @Nonnull
-  public SqlUpdate argDbDate(@Nonnull String argName, @Nullable LocalDate arg) {
-    return namedArg(argName, adaptor.nullDbDate(arg));
+  public SqlUpdate argLocalDate(@Nonnull String argName, @Nullable LocalDate arg) {
+    return namedArg(argName, adaptor.nullLocalDate(arg));
   }
 
   @Nonnull

--- a/src/main/java/com/github/susom/database/SqlUpdateImpl.java
+++ b/src/main/java/com/github/susom/database/SqlUpdateImpl.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -153,6 +154,18 @@ public class SqlUpdateImpl implements SqlUpdate {
   @Nonnull
   public SqlUpdate argDate(@Nonnull String argName, @Nullable Date arg) {
     return namedArg(argName, adaptor.nullDate(arg));
+  }
+
+  @Override
+  @Nonnull
+  public SqlUpdate argDbDate(@Nullable LocalDate arg) {
+    return positionalArg(adaptor.nullDbDate(arg));
+  }
+
+  @Override
+  @Nonnull
+  public SqlUpdate argDbDate(@Nonnull String argName, @Nullable LocalDate arg) {
+    return namedArg(argName, adaptor.nullDbDate(arg));
   }
 
   @Nonnull

--- a/src/main/java/com/github/susom/database/StatementAdaptor.java
+++ b/src/main/java/com/github/susom/database/StatementAdaptor.java
@@ -38,7 +38,6 @@ import org.slf4j.Logger;
 import com.github.susom.database.MixedParameterSql.SecretArg;
 
 import oracle.jdbc.OraclePreparedStatement;
-import org.slf4j.LoggerFactory;
 
 /**
  * Deal with mapping parameters into prepared statements.
@@ -186,10 +185,13 @@ public class StatementAdaptor {
     return new Timestamp(arg.getTime());
   }
 
+
+  // Processes a true date without timestamp information.
   public Object nullLocalDate(LocalDate arg) {
     if (arg == null) {
       return new SqlNull(Types.DATE);
     }
+
     return java.sql.Date.valueOf(arg);
   }
 

--- a/src/main/java/com/github/susom/database/StatementAdaptor.java
+++ b/src/main/java/com/github/susom/database/StatementAdaptor.java
@@ -27,6 +27,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.Scanner;
 
@@ -37,6 +38,7 @@ import org.slf4j.Logger;
 import com.github.susom.database.MixedParameterSql.SecretArg;
 
 import oracle.jdbc.OraclePreparedStatement;
+import org.slf4j.LoggerFactory;
 
 /**
  * Deal with mapping parameters into prepared statements.
@@ -80,6 +82,8 @@ public class StatementAdaptor {
         } else {
           ps.setNull(i + 1, sqlNull.getType());
         }
+      } else if (parameter instanceof java.sql.Date) {
+        ps.setDate( i + 1, (java.sql.Date) parameter);
       } else if (parameter instanceof Date) {
         // this will correct the millis and nanos according to the JDBC spec
         // if a correct Timestamp is passed in, this will detect that and leave it alone
@@ -180,6 +184,15 @@ public class StatementAdaptor {
       return new SqlNull(Types.TIMESTAMP);
     }
     return new Timestamp(arg.getTime());
+  }
+
+  public Object nullDbDate(LocalDate arg) {
+    if (arg == null) {
+      return new SqlNull(Types.DATE);
+    }
+    Logger log = LoggerFactory.getLogger("StatementAdapter.class");
+    log.info("nullDbDate converting arg"+arg.toString()+ " to " + java.sql.Date.valueOf(arg));
+    return java.sql.Date.valueOf(arg);
   }
 
   public Object nullNumeric(Number arg) {

--- a/src/main/java/com/github/susom/database/StatementAdaptor.java
+++ b/src/main/java/com/github/susom/database/StatementAdaptor.java
@@ -27,7 +27,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.time.LocalDate;
+import java.time.*;
 import java.util.Date;
 import java.util.Scanner;
 
@@ -186,7 +186,7 @@ public class StatementAdaptor {
   }
 
 
-  // Processes a true date without timestamp information.
+  // Processes a true date without time information.
   public Object nullLocalDate(LocalDate arg) {
     if (arg == null) {
       return new SqlNull(Types.DATE);

--- a/src/main/java/com/github/susom/database/StatementAdaptor.java
+++ b/src/main/java/com/github/susom/database/StatementAdaptor.java
@@ -186,12 +186,10 @@ public class StatementAdaptor {
     return new Timestamp(arg.getTime());
   }
 
-  public Object nullDbDate(LocalDate arg) {
+  public Object nullLocalDate(LocalDate arg) {
     if (arg == null) {
       return new SqlNull(Types.DATE);
     }
-    Logger log = LoggerFactory.getLogger("StatementAdapter.class");
-    log.info("nullDbDate converting arg"+arg.toString()+ " to " + java.sql.Date.valueOf(arg));
     return java.sql.Date.valueOf(arg);
   }
 

--- a/src/test/java/com/github/susom/database/test/CommonTest.java
+++ b/src/test/java/com/github/susom/database/test/CommonTest.java
@@ -1218,28 +1218,27 @@ public abstract class CommonTest {
   }
 
   @Test
-  @Retry
   public void argLocalDateTimeZones() {
-    // Verify we always get the same LocalDate regardless of time zone and DB
+    LocalDate januaryOne2000 = LocalDate.of(2000, Month.JANUARY, 1);
+
+    // Verify we always get the same LocalDate regardless of time zone and DB across all drivers
     new Schema().addTable("dbtest").addColumn("i").asLocalDate().schema().execute(db);
-    db.toInsert("insert into dbtest (i) values (?)").argLocalDate(localDateNow).insert(1);
+    db.toInsert("insert into dbtest (i) values (?)").argLocalDate(januaryOne2000).insert(1);
 
     // Query without specifying a zone
-    assertEquals(localDateNow,
-        db.toSelect("select i from dbtest where i=?").argLocalDate(localDateNow).queryLocalDateOrNull());
+    assertEquals(januaryOne2000,
+        db.toSelect("select i from dbtest where i=?").argLocalDate(januaryOne2000).queryLocalDateOrNull());
 
-    TimeZone defautTZ = TimeZone.getDefault();
+    TimeZone defaultTZ = TimeZone.getDefault();
 
-    String localDateAsString = localDateNow.toString();
     String[] availableTZs = TimeZone.getAvailableIDs();
     for (String tz : availableTZs) {
       TimeZone.setDefault(TimeZone.getTimeZone(tz));
       LocalDate result =
-        db.toSelect("select i from dbtest where i=?").argLocalDate(localDateNow).queryLocalDateOrNull();
-      assertEquals(localDateNow, result);
-      assertEquals(localDateAsString, result.toString());
+        db.toSelect("select i from dbtest where i=?").argLocalDate(januaryOne2000).queryLocalDateOrNull();
+      assertEquals(januaryOne2000, result);
     }
-    TimeZone.setDefault(defautTZ);
+    TimeZone.setDefault(defaultTZ);
   }
   
   @Test

--- a/src/test/java/com/github/susom/database/test/CommonTest.java
+++ b/src/test/java/com/github/susom/database/test/CommonTest.java
@@ -25,7 +25,6 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.sql.ResultSetMetaData;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.Month;
@@ -64,6 +63,7 @@ import static org.junit.Assert.*;
  * @author garricko
  */
 public abstract class CommonTest {
+
   static {
     // Initialize logging
     String log4jConfig = new File("log4j.xml").getAbsolutePath();
@@ -1620,6 +1620,17 @@ public abstract class CommonTest {
 //    System.err.println("***** d: " + db.select("select d from dbtest").queryString());
 //    System.err.println("***** n: " + dbNow.getTime());
     assertEquals(new Long(1L), db.toSelect("select count(*) from dbtest where d=?").argDate(dbNow).queryLongOrNull());
+  }
+
+  @Test
+  public void daylightSavings() {
+    LocalDate lastStdDateSpring = LocalDate.of(2019, Month.MARCH, 9);
+    LocalDate firstDSTDateSpring = LocalDate.of(2019, Month.MARCH, 10);
+
+    // Verify that the original LocalDate matches the driver SQL LocalDate generated.
+    StatementAdaptor adaptor = new StatementAdaptor(new OptionsDefault(db.flavor()));
+    assertEquals(lastStdDateSpring.toString(), adaptor.nullLocalDate(lastStdDateSpring).toString());
+    assertEquals(firstDSTDateSpring.toString(), adaptor.nullLocalDate(firstDSTDateSpring).toString());
   }
 
   @Test

--- a/src/test/java/com/github/susom/database/test/CommonTest.java
+++ b/src/test/java/com/github/susom/database/test/CommonTest.java
@@ -53,8 +53,6 @@ import com.github.susom.database.RowsHandler;
 import com.github.susom.database.Schema;
 import com.github.susom.database.Sql;
 import com.github.susom.database.SqlArgs;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;
@@ -735,7 +733,6 @@ public abstract class CommonTest {
     db.toInsert(Sql.insert("dbtest2", args)).insertBatch();
 
     assertEquals(2, db.toSelect("select count(*) from dbtest2").queryIntegerOrZero());
-
 
     assertEquals(
         db.toSelect("select nbr_integer, nbr_long, nbr_float, nbr_double, nbr_big_decimal,"
@@ -1602,6 +1599,7 @@ public abstract class CommonTest {
 
   @Test
   public void insertLocalDate() {
+    // Date without time
     new Schema()
             .addTable("dbtest")
             .addColumn("d").asLocalDate().table().schema()

--- a/src/test/java/com/github/susom/database/test/CommonTest.java
+++ b/src/test/java/com/github/susom/database/test/CommonTest.java
@@ -35,24 +35,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
+import com.github.susom.database.*;
 import org.apache.log4j.xml.DOMConfigurator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import com.github.susom.database.ConstraintViolationException;
-import com.github.susom.database.Database;
-import com.github.susom.database.DatabaseException;
-import com.github.susom.database.DatabaseProvider;
-import com.github.susom.database.OptionsOverride;
-import com.github.susom.database.Row;
-import com.github.susom.database.RowHandler;
-import com.github.susom.database.Rows;
-import com.github.susom.database.RowsHandler;
-import com.github.susom.database.Schema;
-import com.github.susom.database.Sql;
-import com.github.susom.database.SqlArgs;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;

--- a/src/test/java/com/github/susom/database/test/RowStubMockDao.java
+++ b/src/test/java/com/github/susom/database/test/RowStubMockDao.java
@@ -1,0 +1,129 @@
+package com.github.susom.database.test;
+
+import com.github.susom.database.Database;
+import com.github.susom.database.RowStub;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.function.Supplier;
+
+/**
+ * Test Create, read, update, and delete using the RowStub implementation.
+ */
+public class RowStubMockDao {
+  private final Supplier<Database> dbp;
+
+  public RowStubMockDao(Supplier<Database> dbp) {
+    this.dbp = dbp;
+  }
+
+  public void create(final RowStubMockData data, Long userIdMakingChange) {
+    Database db = dbp.get();
+
+    Date updateTime = db.nowPerApp();
+    Long dataId = db.toInsert(
+      "insert into dbtest (data_id, name, local_date, update_sequence, update_time) values (?,?,?,0,?)")
+      .argPkSeq("id_seq")
+      .argString(data.getName())
+      .argLocalDate(data.getLocalDate())
+      .argDate(updateTime)
+      .insertReturningPkSeq("data_id");
+
+    // Update the object in memory
+    data.setDataId(dataId);
+    data.setUpdateSequence(0);
+    data.setUpdateTime(updateTime);
+  }
+
+  public RowStubMockData findById(final Long dataId, ColumnLookupType lookupType, boolean lockRow) throws Exception {
+    return dbp.get().toSelect("select name, local_date, update_sequence, update_time from dbtest where data_id=?"
+      + (lockRow ? " for update" : ""))
+      .argLong(dataId).queryOneOrNull(rowStub -> {
+        RowStubMockData result = new RowStubMockData();
+        result.setDataId(dataId);
+        switch (lookupType) {
+          case BY_ORDER:
+            // Hit the column number path getting the results
+            result.setName(rowStub.getStringOrNull());
+            result.setLocalDate(rowStub.getLocalDateOrNull());
+            result.setUpdateSequence(rowStub.getIntegerOrNull());
+            result.setUpdateTime(rowStub.getDateOrNull());
+            break;
+
+          case BY_NAME:
+            // Hig the column name path getting the results
+            result.setName(rowStub.getStringOrNull("name"));
+            result.setLocalDate(rowStub.getLocalDateOrNull("local_date"));
+            result.setUpdateSequence(rowStub.getIntegerOrNull("update_sequence"));
+            result.setUpdateTime(rowStub.getDateOrNull("update_time"));
+            break;
+
+          case BY_NUMBER:
+            // Hit the column number path getting the results
+            result.setName(rowStub.getStringOrNull(1));
+            result.setLocalDate(rowStub.getLocalDateOrNull(2));
+            result.setUpdateSequence(rowStub.getIntegerOrNull(3));
+            result.setUpdateTime(rowStub.getDateOrNull(4));
+            break;
+          default:
+            throw new Exception("Unexpected Lookup Type in findById!");
+        }
+        return result;
+      });
+  }
+
+  public boolean isMidnight(final Long dataId) {
+
+    return dbp.get().toSelect("select local_date from dbtest where data_id=?")
+      .argLong(dataId).queryOneOrNull(rowStub -> {
+        return (rowStub.isMidnight("local_date"));
+      });
+  }
+
+  public boolean isNotMidnight(final Long dataId) {
+
+    return dbp.get().toSelect("select update_time from dbtest where data_id=?")
+      .argLong(dataId).queryOneOrNull(rowStub -> {
+        return (! rowStub.isMidnight("update_time"));
+      });
+  }
+
+  public void update(RowStubMockData data, Long userIdMakingChange) {
+    Database db = dbp.get();
+
+    int newUpdateSequence = data.getUpdateSequence() + 1;
+    Date newUpdateTime = db.nowPerApp();
+    LocalDate newLocalDate = newUpdateTime.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+
+    db.toUpdate("update dbtest set name=?, local_date=?, update_sequence=?, update_time=? where data_id=?")
+      .argString(data.getName())
+      .argInteger(newUpdateSequence)
+      .argLocalDate(newLocalDate)
+      .argDate(newUpdateTime)
+      .argLong(data.getDataId())
+      .update(1);
+
+    // Make sure the object in memory matches the database.
+    data.setLocalDate(newLocalDate);
+    data.setUpdateSequence(newUpdateSequence);
+    data.setUpdateTime(newUpdateTime);
+  }
+
+  public void delete(RowStubMockData data, Long userIdMakingChange) {
+    Database db = dbp.get();
+
+    int newUpdateSequence = data.getUpdateSequence() + 1;
+    Date newUpdateTime = db.nowPerApp();
+
+    db.toDelete("delete from dbtest where data_id=?")
+      .argLong(data.getDataId())
+      .update(1);
+
+    // Make sure the object in memory matches the database.
+    data.setUpdateSequence(newUpdateSequence);
+    data.setUpdateTime(newUpdateTime);
+  }
+
+  public enum ColumnLookupType {BY_ORDER, BY_NAME, BY_NUMBER}
+}

--- a/src/test/java/com/github/susom/database/test/RowStubMockDao.java
+++ b/src/test/java/com/github/susom/database/test/RowStubMockDao.java
@@ -1,7 +1,6 @@
 package com.github.susom.database.test;
 
 import com.github.susom.database.Database;
-import com.github.susom.database.RowStub;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -70,22 +69,6 @@ public class RowStubMockDao {
             throw new Exception("Unexpected Lookup Type in findById!");
         }
         return result;
-      });
-  }
-
-  public boolean isMidnight(final Long dataId) {
-
-    return dbp.get().toSelect("select local_date from dbtest where data_id=?")
-      .argLong(dataId).queryOneOrNull(rowStub -> {
-        return (rowStub.isMidnight("local_date"));
-      });
-  }
-
-  public boolean isNotMidnight(final Long dataId) {
-
-    return dbp.get().toSelect("select update_time from dbtest where data_id=?")
-      .argLong(dataId).queryOneOrNull(rowStub -> {
-        return (! rowStub.isMidnight("update_time"));
       });
   }
 

--- a/src/test/java/com/github/susom/database/test/RowStubMockData.java
+++ b/src/test/java/com/github/susom/database/test/RowStubMockData.java
@@ -1,0 +1,55 @@
+package com.github.susom.database.test;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+/**
+ * Simple bean for use by RowStubMockDao mock testing the RowStub implementation
+ */
+public class RowStubMockData {
+  private Long dataId;
+  private String name;
+  private LocalDate localDate;
+  private Integer updateSequence;
+  private Date updateTime;
+
+  public Long getDataId() {
+    return dataId;
+  }
+
+  public void setDataId(Long dataId) {
+    this.dataId = dataId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public LocalDate getLocalDate() {
+    return localDate;
+  }
+
+  public void setLocalDate(LocalDate localDate) {
+    this.localDate = localDate;
+  }
+
+  public Integer getUpdateSequence() {
+    return updateSequence;
+  }
+
+  public void setUpdateSequence(Integer updateSequence) {
+    this.updateSequence = updateSequence;
+  }
+
+  public Date getUpdateTime() {
+    return updateTime;
+  }
+
+  public void setUpdateTime(Date updateTime) {
+    this.updateTime = updateTime;
+  }
+}

--- a/src/test/java/com/github/susom/database/test/RowStubTest.java
+++ b/src/test/java/com/github/susom/database/test/RowStubTest.java
@@ -178,34 +178,4 @@ public class RowStubTest {
     verify(db).update(anyString(), eq("delete from dbtest where data_id=100"));
     verifyNoMoreInteractions(db);
   }
-
-  @Test
-  public void testIsMidnight() throws Exception {
-    // Configure the mock because our class under test expects values to be returned from the db
-    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
-      .withColumnNames("local_date")
-      .addRow(localDateNow));
-
-    // The test scenario
-    assertTrue( rowStubMockDao.isMidnight(5L));
-
-    // Verify database queries against golden copies
-    verify(db).query(anyString(), eq("select local_date from dbtest where data_id=5"));
-    verifyNoMoreInteractions(db);
-  }
-
-  @Test
-  public void testIsNotMidnight() throws Exception {
-    // Configure the mock because our class under test expects values to be returned from the db
-    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
-      .withColumnNames("update_time")
-      .addRow(now));
-
-    // The test scenario
-    assertTrue( rowStubMockDao.isNotMidnight(6L) );
-
-    // Verify database queries against golden copies
-    verify(db).query(anyString(), eq("select update_time from dbtest where data_id=6"));
-    verifyNoMoreInteractions(db);
-  }
 }

--- a/src/test/java/com/github/susom/database/test/RowStubTest.java
+++ b/src/test/java/com/github/susom/database/test/RowStubTest.java
@@ -1,0 +1,211 @@
+package com.github.susom.database.test;
+
+import com.github.susom.database.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for exercising the RowStub implementation
+ */
+public class RowStubTest {
+  @Mock
+  private DatabaseMock db;
+  private Date now = new Date();
+  private LocalDate localDateNow = LocalDate.now();
+  private RowStubMockDao rowStubMockDao;
+
+  @Before
+  public void initializeMocks() {
+    MockitoAnnotations.initMocks(this);
+
+    // This is the key for database mocking. Explicitly create our DatabaseImpl and give it our mock.
+    // Could use any Flavor here, though postgres/oracle are a little easier than derby because
+    // they create single operations for insert returning.
+    rowStubMockDao = new RowStubMockDao(new DatabaseImpl(db, new OptionsOverride(Flavor.postgresql) {
+      @Override
+      public Date currentDate() {
+        // Use a local variable from the test so we can verify in a deterministic way
+        return now;
+      }
+    }));
+  }
+
+  @Test
+  public void testCreate() throws Exception {
+    // Configure the mock because DAO expects the pk to be returned from the insert
+    when(db.insertReturningPk(anyString(), anyString())).thenReturn(1L);
+
+    RowStubMockData data = new RowStubMockData();
+    data.setName("Foo");
+    data.setLocalDate(localDateNow);
+
+    rowStubMockDao.create(data, 1L);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(1L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(0), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify SQL executed against golden copies
+    verify(db).insertReturningPk(eq("insert into dbtest (data_id, name, local_date, update_sequence, update_time) values (nextval('id_seq'),?,?,0,?)"), anyString());
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testFindByColumnOrder() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("name", "local_date", "update_sequence", "update_time")
+      .addRow("Foo", localDateNow, 3, now));
+
+    // The test scenario
+    RowStubMockData data = rowStubMockDao.findById(12L, RowStubMockDao.ColumnLookupType.BY_ORDER, false);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(12L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(3), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).query(anyString(), eq("select name, local_date, update_sequence, update_time from dbtest where data_id=12"));
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testFindByColumnNames() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("name", "local_date", "update_sequence", "update_time")
+      .addRow("Foo", localDateNow, 3, now));
+
+    // The test scenario
+    RowStubMockData data = rowStubMockDao.findById(13L, RowStubMockDao.ColumnLookupType.BY_NAME, false);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(13L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(3), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).query(anyString(), eq("select name, local_date, update_sequence, update_time from dbtest where data_id=13"));
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testFindAndLock() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("name", "local_date", "update_sequence", "update_time")
+      .addRow("Foo", localDateNow, 3, now));
+
+    // The test scenario
+    RowStubMockData data = rowStubMockDao.findById(15L, RowStubMockDao.ColumnLookupType.BY_NUMBER, true);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(15L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(3), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).query(anyString(), eq("select name, local_date, update_sequence, update_time from dbtest where data_id=15 for update"));
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testUpdate() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("name", "local_date", "update_sequence", "update_time")
+      .addRow("Foo", localDateNow, 3, now));
+    Date before = new Date(now.getTime() - 5000);
+
+    RowStubMockData data = new RowStubMockData();
+    data.setDataId(100L);
+    data.setName("Foo");
+    data.setLocalDate(localDateNow);
+    data.setUpdateSequence(13);
+    data.setUpdateTime(before);
+    rowStubMockDao.update(data, 23L);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(100L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(14), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).update(eq("update dbtest set name=?, local_date=?, update_sequence=?, update_time=? where data_id=?"), anyString());
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Date before = new Date(now.getTime() - 5000);
+
+    RowStubMockData data = new RowStubMockData();
+    data.setDataId(100L);
+    data.setName("Foo");
+    data.setUpdateSequence(13);
+    data.setUpdateTime(before);
+    rowStubMockDao.delete(data, 23L);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(100L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(new Integer(14), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).update(anyString(), eq("delete from dbtest where data_id=100"));
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testIsMidnight() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("local_date")
+      .addRow(localDateNow));
+
+    // The test scenario
+    assertTrue( rowStubMockDao.isMidnight(5L));
+
+    // Verify database queries against golden copies
+    verify(db).query(anyString(), eq("select local_date from dbtest where data_id=5"));
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testIsNotMidnight() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("update_time")
+      .addRow(now));
+
+    // The test scenario
+    assertTrue( rowStubMockDao.isNotMidnight(6L) );
+
+    // Verify database queries against golden copies
+    verify(db).query(anyString(), eq("select update_time from dbtest where data_id=6"));
+    verifyNoMoreInteractions(db);
+  }
+}

--- a/src/test/java/com/github/susom/database/test/SqlArgsTest.java
+++ b/src/test/java/com/github/susom/database/test/SqlArgsTest.java
@@ -1,8 +1,10 @@
 package com.github.susom.database.test;
 
+import com.github.susom.database.*;
 import org.junit.Test;
 
-import com.github.susom.database.SqlArgs;
+import java.time.LocalDate;
+import java.time.Month;
 
 import static org.junit.Assert.*;
 
@@ -12,7 +14,18 @@ import static org.junit.Assert.*;
  * @author garricko
  */
 public class SqlArgsTest {
+
   @Test
+  public void testLocalDateArgs() {
+    SqlArgs args = new SqlArgs();
+    args.argLocalDate(LocalDate.of(2019, Month.JANUARY, 1));
+    args.argLocalDate(LocalDate.of(2019, Month.DECEMBER, 31));
+
+    assertEquals(2, args.argCount());
+    assertEquals("SqlArgs[{name=null, type=LocalDate, arg=2019-01-01}, {name=null, type=LocalDate, arg=2019-12-31}]",
+      args.toString());
+  }
+
   public void testTidyColumnNames() throws Exception {
     assertArrayEquals(new String[] { "column_1", "column_2", "a", "a_2", "a_3", "a1" },
         SqlArgs.tidyColumnNames(new String[] { null, "", " a ", "a  ", "#!@#$_a","#!@#$_1" }));

--- a/src/test/java/com/github/susom/database/test/SqlArgsTest.java
+++ b/src/test/java/com/github/susom/database/test/SqlArgsTest.java
@@ -26,6 +26,7 @@ public class SqlArgsTest {
       args.toString());
   }
 
+  @Test
   public void testTidyColumnNames() throws Exception {
     assertArrayEquals(new String[] { "column_1", "column_2", "a", "a_2", "a_3", "a1" },
         SqlArgs.tidyColumnNames(new String[] { null, "", " a ", "a  ", "#!@#$_a","#!@#$_1" }));


### PR DESCRIPTION
Currently the Susom database API supports the date type as date/time only.  This is really helpful for ensuring fields like create and update times are properly handled, but it's not ideal for tables with fields like date of birth which are used by the sleep survey.

For the ASQ prototype, we should be using a true DB date on some fields.

This ticket tracks the work to extend the API to support this real DB date type.

This has been tested on Derby, HSQL, Postgres (the prototype target DB).  I do not currently have an Oracle DB or SQL Server DB available for testing.  I'm not sure if I need to install those databases on my laptop or if Garrick has a developer test environment that can be used.  Before investing time in that, I wanted to verify whether Garrick is OK with the general approach.