### PR TITLE
Clean LocalDate extensions for SuSoM Database framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,40 @@ there is also a configuration option to make the above code do exactly the same 
 `argDateNowPerApp()` so you can in effect control the database server time as well as that
 of the application server.
 
+#### Support for java.time.LocalDate
+
+There are use cases where a true database date is more appropriate than a timestamp, 
+e.g., for recording date of birth or other fields where time is not really relevant or 
+known. The LocalDate API is stored as a database Date, not a Timestamp, for modern
+databases that support a true date type.
+
+LocalDate has been implemented and tested using ISO 8601 format YYYY-MM-DD.  There should be
+no time or timezone associated.
+
+Postgres and MS SQLServer have implemented a fully compliant LocalDate that is consistentently
+returned as java.sql.Date.   There are no known issues with these databases.
+ 
+Oracle does not support a true date type; the Oracle Date is actually implemented as a 
+timestamp.  Oracle supports LocalDate by using a time of midnight and a timezone of 0. 
+As a result, there are times when the database type returned have been timestamp. 
+
+HSQLDB also does not support a true date type - it's date implementation uses a timestamp of 
+0 (midnight), but has a bug that sets timezone. For this reason, if a date is stored from one 
+timezone (e.g., system default timezone), and a user attempts to query for that date from 
+another timezone, it may not find the value.  For this reason, HSQLDB is not recommended for 
+LocalDate type data if you are working across time zones.
+
+To work around old database implementations of LocalDate as a Timestamp, when a timestamp is
+received, the scale attribute is examined.  A scale of 0 on a Timestamp is always associated 
+with a LocalDate across all tested DB implementations; true timestamps always have a non-zero scale.  
+When a scale of zero is found, it is handled as LocalDate.
+
+More information on specific implementations is available here: 
+* Derby: https://db.apache.org/derby/papers/JDBCImplementation.html#Derby+SQL+DATE
+* HSQLDB: http://www.h2database.com/html/datatypes.html
+  * known problem:http://www.h2database.com/html/datatypes.html
+* Oracle: https://docs.oracle.com/javase/8/docs/api/java/sql/Timestamp.html
+
 #### Correct handling of java.math.BigDecimal
 
 Similarly BigDecimal tries to maintain scale in a more intuitive manner

--- a/demo/database-demo.iml
+++ b/demo/database-demo.iml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
@@ -9,30 +11,30 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="database" />
+    <orderEntry type="library" name="Maven: com.github.susom:database:3.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:3.0.2" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
-    <orderEntry type="library" name="Maven: io.vertx:vertx-core:3.4.2" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-common:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-buffer:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-transport:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-handler:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-handler-proxy:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-socks:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-http:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-http2:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-resolver:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-resolver-dns:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-dns:4.1.8.Final" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.7.4" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.7.4" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.7.0" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-server:9.4.6.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.9.8" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.9.0" level="project" />
+    <orderEntry type="library" name="Maven: io.vertx:vertx-core:3.5.4" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-common:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-buffer:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-transport:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-handler:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-handler-proxy:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-socks:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-http:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-http2:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-resolver:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-resolver-dns:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-dns:4.1.19.Final" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.9.6" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-server:9.4.17.v20190418" level="project" />
     <orderEntry type="library" name="Maven: javax.servlet:javax.servlet-api:3.1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-http:9.4.6.v20170531" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util:9.4.6.v20170531" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-io:9.4.6.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-http:9.4.17.v20190418" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util:9.4.17.v20190418" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-io:9.4.17.v20190418" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:checker-qual:2.1.14" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:checker:2.1.14" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:jdk8:2.1.14" level="project" />

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.github.susom</groupId>
       <artifactId>database</artifactId>
-      <version>3.0-SNAPSHOT</version>
+      <version>3.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -257,11 +257,16 @@
       <version>3.0.2</version>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.25</version>
     </dependency>
-
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>

--- a/src/main/java/com/github/susom/database/DebugSql.java
+++ b/src/main/java/com/github/susom/database/DebugSql.java
@@ -93,8 +93,10 @@ public class DebugSql {
             }
           } else if (argToPrint instanceof StatementAdaptor.SqlNull || argToPrint == null) {
             buf.append("null");
-          } else if (argToPrint instanceof Date) {
+          } else if (argToPrint instanceof java.sql.Timestamp) {
             buf.append(options.flavor().dateAsSqlFunction((Date) argToPrint, options.calendarForTimestamps()));
+          } else if (argToPrint instanceof java.sql.Date) {
+              buf.append(options.flavor().localDateAsSqlFunction((Date) argToPrint));
           } else if (argToPrint instanceof Number) {
             buf.append(argToPrint);
           } else if (argToPrint instanceof Boolean) {

--- a/src/main/java/com/github/susom/database/Flavor.java
+++ b/src/main/java/com/github/susom/database/Flavor.java
@@ -91,6 +91,11 @@ public enum Flavor {
     }
 
     @Override
+    public String typeLocalDate() {
+      return "date";
+    }
+
+    @Override
     public boolean useStringForClob() {
       return false;
     }
@@ -153,6 +158,11 @@ public enum Flavor {
     }
 
     @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "'" + date.toString() + "'";
+    }
+
+    @Override
     public String sequenceOptions() {
       return " as bigint";
     }
@@ -196,6 +206,11 @@ public enum Flavor {
     @Override
     public String typeDate() {
       return "datetime2(3)";
+    }
+
+    @Override
+    public String typeLocalDate() {
+      return "date";
     }
 
     @Override
@@ -283,6 +298,11 @@ public enum Flavor {
     }
 
     @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "'" + date.toString() + "'";
+    }
+
+    @Override
     public String sequenceOptions() {
       return "";
     }
@@ -326,6 +346,11 @@ public enum Flavor {
     @Override
     public String typeDate() {
       return "timestamp(3)";
+    }
+
+    @Override
+    public String typeLocalDate() {
+      return "date";
     }
 
     @Override
@@ -411,6 +436,11 @@ public enum Flavor {
     }
 
     @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "to_date('" + date.toString() + "', 'yyyy-mm-dd')";
+    }
+
+    @Override
     public String sequenceOptions() {
       return "";
     }
@@ -477,6 +507,11 @@ public enum Flavor {
     }
 
     @Override
+    public String typeLocalDate() {
+      return "date";
+    }
+
+    @Override
     public boolean useStringForClob() {
       return true;
     }
@@ -536,6 +571,11 @@ public enum Flavor {
       SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS000");
       dateFormat.setCalendar(calendar);
       return "'" + dateFormat.format(date) + " GMT'::timestamp";
+    }
+
+    @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "'" + date.toString()+"'";
     }
 
     @Override
@@ -604,6 +644,11 @@ public enum Flavor {
     }
 
     @Override
+    public String typeLocalDate() {
+      return "date";
+    }
+
+    @Override
     public boolean useStringForClob() {
       return true;
     }
@@ -666,6 +711,11 @@ public enum Flavor {
     }
 
     @Override
+    public String localDateAsSqlFunction(Date date) {
+      return "'" + date.toString()+"'";
+    }
+
+    @Override
     public String sequenceOptions() {
       return " as bigint";
     }
@@ -696,6 +746,8 @@ public enum Flavor {
   public abstract String typeBlob();
 
   public abstract String typeDate();
+
+  public abstract String typeLocalDate();
 
   public abstract boolean useStringForClob();
 
@@ -729,6 +781,11 @@ public enum Flavor {
    * looks like "'1970-01-02 02:17:36.789000 GMT'::timestamp".
    */
   public abstract String dateAsSqlFunction(Date date, Calendar calendar);
+
+/**
+ * Return a SQL function representing the specified date without time.
+ */
+  public abstract String localDateAsSqlFunction(Date date);
 
   public abstract String sequenceOptions();
 

--- a/src/main/java/com/github/susom/database/Row.java
+++ b/src/main/java/com/github/susom/database/Row.java
@@ -20,6 +20,8 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.sql.ResultSetMetaData;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import javax.annotation.Nonnull;
@@ -443,4 +445,27 @@ public interface Row {
 
   @Nullable
   Date getDateOrNull(String columnName);
+
+  /**
+   * Retrieve column as LocalDate, .i.e, date with no time.
+   * @return LocalDate of the database column value
+   */
+  @Nullable
+  LocalDate getLocalDateOrNull();
+
+  /**
+   * Get the Date field, with no timestamp
+   * @param columnOneBased column number starting at 1, not 0
+   * @return LocalDate of the column value
+   */
+  @Nullable
+  LocalDate getLocalDateOrNull(int columnOneBased);
+
+  /**
+   * Get the Date field, with no timestamp
+   * @param columnName column name to retrieve
+   * @return LocalDate of the column value
+   */
+  @Nullable
+  LocalDate getLocalDateOrNull(String columnName);
 }

--- a/src/main/java/com/github/susom/database/RowStub.java
+++ b/src/main/java/com/github/susom/database/RowStub.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -641,6 +642,44 @@ public class RowStub {
         return toDate(rows.get(row)[columnIndexByName(columnName)]);
       }
 
+      /**
+       * Returns a java.time.LocalDate.  It will have no timezone or other time data.
+       * If you require time, use the Date APIs instead.
+       *
+       * @return
+       */
+      @Nullable
+      @Override
+      public LocalDate getLocalDateOrNull() {
+        return toLocalDate(rows.get(row)[++col]);
+      }
+
+      /**
+       * Returns a java.time.LocalDate.  It will have no timezone or other time data.
+       * If you require time, use the Date APIs instead.
+       *
+       * @return
+       */
+      @Nullable
+      @Override
+      public LocalDate getLocalDateOrNull(int columnOneBased) {
+        col = columnOneBased;
+        return toLocalDate(rows.get(row)[columnOneBased-1]);
+      }
+
+      /**
+       * Returns a java.time.LocalDate.  It will have no timezone or other time data.
+       * If you require time, use the Date APIs instead.
+       *
+       * @return
+       */
+      @Nullable
+      @Override
+      public LocalDate getLocalDateOrNull(String columnName) {
+        col = columnIndexByName(columnName) + 1;
+        return toLocalDate(rows.get(row)[columnIndexByName(columnName)]);
+      }
+
       private void requireColumnNames() {
         if (columnNames == null) {
           throw new DatabaseException("Column names were not provided for this stub");
@@ -722,6 +761,11 @@ public class RowStub {
         return (String) o;
       }
 
+      /**
+       * Returns a java.util.Date.  It may be used for dates or times.
+       *
+       * @return
+       */
       private Date toDate(Object o) {
         if (o instanceof String) {
           String s = (String) o;
@@ -742,6 +786,20 @@ public class RowStub {
           throw new DatabaseException("Didn't understand date string: " + s);
         }
         return (Date) o;
+      }
+
+      /**
+       * Returns a LocalDate (no time).
+       * If the object is a String, it should be in ISO 8601 format.
+       *
+       * @return a LocalDate representation of the object
+       */
+      private LocalDate toLocalDate(Object o) {
+        if (o instanceof String) {
+          return LocalDate.parse((String) o);
+        }
+
+        return (LocalDate) o;
       }
     };
   }

--- a/src/main/java/com/github/susom/database/RowsAdaptor.java
+++ b/src/main/java/com/github/susom/database/RowsAdaptor.java
@@ -25,6 +25,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.Date;
 
 import javax.annotation.Nonnull;
@@ -684,6 +685,7 @@ class RowsAdaptor implements Rows {
     return getDateOrNull(column++);
   }
 
+  @Nullable
   @Override
   public Date getDateOrNull(int columnOneBased) {
     try {
@@ -694,11 +696,40 @@ class RowsAdaptor implements Rows {
     }
   }
 
+  @Nullable
   @Override
   public Date getDateOrNull(String columnName) {
     try {
       column = rs.findColumn(columnName) + 1;
       return toDate(rs, columnName);
+    } catch (SQLException e) {
+      throw new DatabaseException(e);
+    }
+  }
+
+  @Nullable
+  @Override
+  public LocalDate getLocalDateOrNull() {
+    return getLocalDateOrNull(column++);
+  }
+
+  @Nullable
+  @Override
+  public LocalDate getLocalDateOrNull(int columnOneBased) {
+    try {
+      column = columnOneBased + 1;
+      return toLocalDate(rs, columnOneBased);
+    } catch (SQLException e) {
+      throw new DatabaseException(e);
+    }
+  }
+
+  @Nullable
+  @Override
+  public LocalDate getLocalDateOrNull(String columnName) {
+    try {
+      column = rs.findColumn(columnName) + 1;
+      return toLocalDate(rs, columnName);
     } catch (SQLException e) {
       throw new DatabaseException(e);
     }
@@ -722,6 +753,16 @@ class RowsAdaptor implements Rows {
   private Date toDate(ResultSet rs, String col) throws SQLException {
     Timestamp val = rs.getTimestamp(col, options.calendarForTimestamps());
     return val == null ? null : timestampToDate(val);
+  }
+
+  private LocalDate toLocalDate(ResultSet rs, int col) throws SQLException {
+    java.sql.Date val = rs.getDate(col);
+    return val == null ? null : val.toLocalDate();
+  }
+
+  private LocalDate toLocalDate(ResultSet rs, String col) throws SQLException {
+    java.sql.Date val = rs.getDate(col);
+    return val == null ? null : val.toLocalDate();
   }
 
   private Boolean toBoolean(ResultSet rs, int col) throws SQLException {

--- a/src/main/java/com/github/susom/database/SqlInsert.java
+++ b/src/main/java/com/github/susom/database/SqlInsert.java
@@ -19,6 +19,7 @@ package com.github.susom.database;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Date;
 
 import javax.annotation.CheckReturnValue;
@@ -88,11 +89,19 @@ public interface SqlInsert {
 
   @Nonnull
   @CheckReturnValue
-  SqlInsert argDate(Date arg);
+  SqlInsert argDate(Date arg); // date with time
 
   @Nonnull
   @CheckReturnValue
-  SqlInsert argDate(@Nonnull String argName, Date arg);
+  SqlInsert argDate(@Nonnull String argName, Date arg); // date with time
+
+  @Nonnull
+  @CheckReturnValue
+  SqlInsert argLocalDate(LocalDate arg); // date only - no timestamp
+
+  @Nonnull
+  @CheckReturnValue
+  SqlInsert argLocalDate(@Nonnull String argName, LocalDate arg);  // date only - no timestamp
 
   @Nonnull
   @CheckReturnValue

--- a/src/main/java/com/github/susom/database/SqlInsertImpl.java
+++ b/src/main/java/com/github/susom/database/SqlInsertImpl.java
@@ -24,6 +24,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -160,6 +161,18 @@ public class SqlInsertImpl implements SqlInsert {
   @Nonnull
   public SqlInsert argDate(@Nonnull String argName, Date arg) {
     return namedArg(argName, adaptor.nullDate(arg));
+  }
+
+  @Override
+  @Nonnull
+  public SqlInsert argLocalDate(@Nonnull String argName, LocalDate arg) {
+    return namedArg(argName, adaptor.nullLocalDate(arg));
+  }
+
+  @Override
+  @Nonnull
+  public SqlInsert argLocalDate(LocalDate arg) {
+    return positionalArg(adaptor.nullLocalDate(arg));
   }
 
   @Nonnull

--- a/src/main/java/com/github/susom/database/SqlSelect.java
+++ b/src/main/java/com/github/susom/database/SqlSelect.java
@@ -17,6 +17,7 @@
 package com.github.susom.database;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 
@@ -88,11 +89,19 @@ public interface SqlSelect {
 
   @Nonnull
   @CheckReturnValue
-  SqlSelect argDate(Date arg);
+  SqlSelect argDate(Date arg);  // Date with time
 
   @Nonnull
   @CheckReturnValue
-  SqlSelect argDate(@Nonnull String argName, Date arg);
+  SqlSelect argDate(@Nonnull String argName, Date arg);  // Date with time
+
+  @Nonnull
+  @CheckReturnValue
+  SqlSelect argLocalDate(LocalDate arg); // Date without time
+
+  @Nonnull
+  @CheckReturnValue
+  SqlSelect argLocalDate(@Nonnull String argName, LocalDate arg); // Date without time
 
   @Nonnull
   @CheckReturnValue
@@ -224,11 +233,19 @@ public interface SqlSelect {
 
   @Nullable
   @CheckReturnValue
-  Date queryDateOrNull();
+  Date queryDateOrNull();  // Date with time
 
   @Nonnull
   @CheckReturnValue
-  List<Date> queryDates();
+  List<Date> queryDates();  // Date with time
+
+  @Nullable
+  @CheckReturnValue
+  LocalDate queryLocalDateOrNull();  // Date without time
+
+  @Nonnull
+  @CheckReturnValue
+  List<LocalDate> queryLocalDates();  // Date without time
 
   /**
    * This is the most generic and low-level way to iterate the query results.

--- a/src/main/java/com/github/susom/database/SqlSelectImpl.java
+++ b/src/main/java/com/github/susom/database/SqlSelectImpl.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -150,13 +151,29 @@ public class SqlSelectImpl implements SqlSelect {
   @Nonnull
   @Override
   public SqlSelect argDate(Date arg) {
+    // Date with time
     return positionalArg(adaptor.nullDate(arg));
   }
 
   @Nonnull
   @Override
   public SqlSelect argDate(@Nonnull String argName, Date arg) {
+    // Date with time
     return namedArg(argName, adaptor.nullDate(arg));
+  }
+
+  @Nonnull
+  @Override
+  public SqlSelect argLocalDate(LocalDate arg) {
+    // Date with no time
+    return positionalArg(adaptor.nullLocalDate(arg));
+  }
+
+  @Nonnull
+  @Override
+  public SqlSelect argLocalDate(@Nonnull String argName, LocalDate arg) {
+    // Date with no time
+    return namedArg(argName, adaptor.nullLocalDate(arg));
   }
 
   @Nonnull
@@ -543,6 +560,40 @@ public class SqlSelectImpl implements SqlSelect {
         List<Date> result = new ArrayList<>();
         while (rs.next()) {
           Date value = rs.getDateOrNull(1);
+          if (value != null) {
+            result.add(value);
+          }
+        }
+        return result;
+      }
+    });
+  }
+
+  @Nullable
+  @Override
+  public LocalDate queryLocalDateOrNull() {
+    // Date without time
+    return queryWithTimeout(new RowsHandler<LocalDate>() {
+      @Override
+      public LocalDate process(Rows rs) throws Exception {
+        if (rs.next()) {
+          return rs.getLocalDateOrNull(1);
+        }
+        return null;
+      }
+    });
+  }
+
+  @Nonnull
+  @Override
+  public List<LocalDate> queryLocalDates() {
+    // Date without time
+    return queryWithTimeout(new RowsHandler<List<LocalDate>>() {
+      @Override
+      public List<LocalDate> process(Rows rs) throws Exception {
+        List<LocalDate> result = new ArrayList<>();
+        while (rs.next()) {
+          LocalDate value = rs.getLocalDateOrNull(1);
           if (value != null) {
             result.add(value);
           }

--- a/src/main/java/com/github/susom/database/SqlUpdate.java
+++ b/src/main/java/com/github/susom/database/SqlUpdate.java
@@ -19,6 +19,7 @@ package com.github.susom.database;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Date;
 
 import javax.annotation.CheckReturnValue;
@@ -89,11 +90,19 @@ public interface SqlUpdate {
 
   @Nonnull
   @CheckReturnValue
-  SqlUpdate argDate(@Nullable Date arg);
+  SqlUpdate argDate(@Nullable Date arg);  // Date with timestamp
 
   @Nonnull
   @CheckReturnValue
-  SqlUpdate argDate(@Nonnull String argName, @Nullable Date arg);
+  SqlUpdate argDate(@Nonnull String argName, @Nullable Date arg); // Date with timestamp
+
+  @Nonnull
+  @CheckReturnValue
+  SqlUpdate argLocalDate(@Nullable LocalDate arg);  // Date only - no timestamp
+
+  @Nonnull
+  @CheckReturnValue
+  SqlUpdate argLocalDate(@Nonnull String argName, @Nullable LocalDate arg); // Date only - no timestamp
 
   @Nonnull
   @CheckReturnValue

--- a/src/main/java/com/github/susom/database/SqlUpdateImpl.java
+++ b/src/main/java/com/github/susom/database/SqlUpdateImpl.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -146,13 +147,29 @@ public class SqlUpdateImpl implements SqlUpdate {
   @Override
   @Nonnull
   public SqlUpdate argDate(@Nullable Date arg) {
+    // Date with time
     return positionalArg(adaptor.nullDate(arg));
   }
 
   @Override
   @Nonnull
   public SqlUpdate argDate(@Nonnull String argName, @Nullable Date arg) {
+    // Date with time
     return namedArg(argName, adaptor.nullDate(arg));
+  }
+
+  @Override
+  @Nonnull
+  public SqlUpdate argLocalDate(@Nullable LocalDate arg) {
+    // Date with no time
+    return positionalArg(adaptor.nullLocalDate(arg));
+  }
+
+  @Override
+  @Nonnull
+  public SqlUpdate argLocalDate(@Nonnull String argName, @Nullable LocalDate arg) {
+    // Date with no time
+    return namedArg(argName, adaptor.nullLocalDate(arg));
   }
 
   @Nonnull

--- a/src/main/java/com/github/susom/database/StatementAdaptor.java
+++ b/src/main/java/com/github/susom/database/StatementAdaptor.java
@@ -27,6 +27,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.Scanner;
 
@@ -80,6 +81,8 @@ public class StatementAdaptor {
         } else {
           ps.setNull(i + 1, sqlNull.getType());
         }
+      } else if (parameter instanceof java.sql.Date) {
+        ps.setDate( i + 1, (java.sql.Date) parameter);
       } else if (parameter instanceof Date) {
         // this will correct the millis and nanos according to the JDBC spec
         // if a correct Timestamp is passed in, this will detect that and leave it alone
@@ -180,6 +183,16 @@ public class StatementAdaptor {
       return new SqlNull(Types.TIMESTAMP);
     }
     return new Timestamp(arg.getTime());
+  }
+
+
+  // Processes a true date without time information.
+  public Object nullLocalDate(LocalDate arg) {
+    if (arg == null) {
+      return new SqlNull(Types.DATE);
+    }
+
+    return java.sql.Date.valueOf(arg);
   }
 
   public Object nullNumeric(Number arg) {

--- a/src/test/java/com/github/susom/database/test/DatabaseTest.java
+++ b/src/test/java/com/github/susom/database/test/DatabaseTest.java
@@ -50,7 +50,7 @@ import com.github.susom.database.OptionsOverride;
 
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.StringContains.containsString;
 
 /**
  * Unit tests for the Database and Sql implementation classes.

--- a/src/test/java/com/github/susom/database/test/RowStubMockDao.java
+++ b/src/test/java/com/github/susom/database/test/RowStubMockDao.java
@@ -1,0 +1,112 @@
+package com.github.susom.database.test;
+
+import com.github.susom.database.Database;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.function.Supplier;
+
+/**
+ * Test Create, read, update, and delete using the RowStub implementation.
+ */
+public class RowStubMockDao {
+  private final Supplier<Database> dbp;
+
+  public RowStubMockDao(Supplier<Database> dbp) {
+    this.dbp = dbp;
+  }
+
+  public void create(final RowStubMockData data, Long userIdMakingChange) {
+    Database db = dbp.get();
+
+    Date updateTime = db.nowPerApp();
+    Long dataId = db.toInsert(
+      "insert into dbtest (data_id, name, local_date, update_sequence, update_time) values (?,?,?,0,?)")
+      .argPkSeq("id_seq")
+      .argString(data.getName())
+      .argLocalDate(data.getLocalDate())
+      .argDate(updateTime)
+      .insertReturningPkSeq("data_id");
+
+    // Update the object in memory
+    data.setDataId(dataId);
+    data.setUpdateSequence(0);
+    data.setUpdateTime(updateTime);
+  }
+
+  public RowStubMockData findById(final Long dataId, ColumnLookupType lookupType, boolean lockRow) throws Exception {
+    return dbp.get().toSelect("select name, local_date, update_sequence, update_time from dbtest where data_id=?"
+      + (lockRow ? " for update" : ""))
+      .argLong(dataId).queryOneOrNull(rowStub -> {
+        RowStubMockData result = new RowStubMockData();
+        result.setDataId(dataId);
+        switch (lookupType) {
+          case BY_ORDER:
+            // Hit the column number path getting the results
+            result.setName(rowStub.getStringOrNull());
+            result.setLocalDate(rowStub.getLocalDateOrNull());
+            result.setUpdateSequence(rowStub.getIntegerOrNull());
+            result.setUpdateTime(rowStub.getDateOrNull());
+            break;
+
+          case BY_NAME:
+            // Hig the column name path getting the results
+            result.setName(rowStub.getStringOrNull("name"));
+            result.setLocalDate(rowStub.getLocalDateOrNull("local_date"));
+            result.setUpdateSequence(rowStub.getIntegerOrNull("update_sequence"));
+            result.setUpdateTime(rowStub.getDateOrNull("update_time"));
+            break;
+
+          case BY_NUMBER:
+            // Hit the column number path getting the results
+            result.setName(rowStub.getStringOrNull(1));
+            result.setLocalDate(rowStub.getLocalDateOrNull(2));
+            result.setUpdateSequence(rowStub.getIntegerOrNull(3));
+            result.setUpdateTime(rowStub.getDateOrNull(4));
+            break;
+          default:
+            throw new Exception("Unexpected Lookup Type in findById!");
+        }
+        return result;
+      });
+  }
+
+  public void update(RowStubMockData data, Long userIdMakingChange) {
+    Database db = dbp.get();
+
+    int newUpdateSequence = data.getUpdateSequence() + 1;
+    Date newUpdateTime = db.nowPerApp();
+    LocalDate newLocalDate = newUpdateTime.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+
+    db.toUpdate("update dbtest set name=?, local_date=?, update_sequence=?, update_time=? where data_id=?")
+      .argString(data.getName())
+      .argInteger(newUpdateSequence)
+      .argLocalDate(newLocalDate)
+      .argDate(newUpdateTime)
+      .argLong(data.getDataId())
+      .update(1);
+
+    // Make sure the object in memory matches the database.
+    data.setLocalDate(newLocalDate);
+    data.setUpdateSequence(newUpdateSequence);
+    data.setUpdateTime(newUpdateTime);
+  }
+
+  public void delete(RowStubMockData data, Long userIdMakingChange) {
+    Database db = dbp.get();
+
+    int newUpdateSequence = data.getUpdateSequence() + 1;
+    Date newUpdateTime = db.nowPerApp();
+
+    db.toDelete("delete from dbtest where data_id=?")
+      .argLong(data.getDataId())
+      .update(1);
+
+    // Make sure the object in memory matches the database.
+    data.setUpdateSequence(newUpdateSequence);
+    data.setUpdateTime(newUpdateTime);
+  }
+
+  public enum ColumnLookupType {BY_ORDER, BY_NAME, BY_NUMBER}
+}

--- a/src/test/java/com/github/susom/database/test/RowStubMockData.java
+++ b/src/test/java/com/github/susom/database/test/RowStubMockData.java
@@ -1,0 +1,55 @@
+package com.github.susom.database.test;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+/**
+ * Simple bean for use by RowStubMockDao mock testing the RowStub implementation
+ */
+public class RowStubMockData {
+  private Long dataId;
+  private String name;
+  private LocalDate localDate;
+  private Integer updateSequence;
+  private Date updateTime;
+
+  public Long getDataId() {
+    return dataId;
+  }
+
+  public void setDataId(Long dataId) {
+    this.dataId = dataId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public LocalDate getLocalDate() {
+    return localDate;
+  }
+
+  public void setLocalDate(LocalDate localDate) {
+    this.localDate = localDate;
+  }
+
+  public Integer getUpdateSequence() {
+    return updateSequence;
+  }
+
+  public void setUpdateSequence(Integer updateSequence) {
+    this.updateSequence = updateSequence;
+  }
+
+  public Date getUpdateTime() {
+    return updateTime;
+  }
+
+  public void setUpdateTime(Date updateTime) {
+    this.updateTime = updateTime;
+  }
+}

--- a/src/test/java/com/github/susom/database/test/RowStubTest.java
+++ b/src/test/java/com/github/susom/database/test/RowStubTest.java
@@ -1,0 +1,181 @@
+package com.github.susom.database.test;
+
+import com.github.susom.database.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for exercising the RowStub implementation
+ */
+public class RowStubTest {
+  @Mock
+  private DatabaseMock db;
+  private Date now = new Date();
+  private LocalDate localDateNow = LocalDate.now();
+  private RowStubMockDao rowStubMockDao;
+
+  @Before
+  public void initializeMocks() {
+    MockitoAnnotations.initMocks(this);
+
+    // This is the key for database mocking. Explicitly create our DatabaseImpl and give it our mock.
+    // Could use any Flavor here, though postgres/oracle are a little easier than derby because
+    // they create single operations for insert returning.
+    rowStubMockDao = new RowStubMockDao(new DatabaseImpl(db, new OptionsOverride(Flavor.postgresql) {
+      @Override
+      public Date currentDate() {
+        // Use a local variable from the test so we can verify in a deterministic way
+        return now;
+      }
+    }));
+  }
+
+  @Test
+  public void testCreate() throws Exception {
+    // Configure the mock because DAO expects the pk to be returned from the insert
+    when(db.insertReturningPk(anyString(), anyString())).thenReturn(1L);
+
+    RowStubMockData data = new RowStubMockData();
+    data.setName("Foo");
+    data.setLocalDate(localDateNow);
+
+    rowStubMockDao.create(data, 1L);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(1L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(0), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify SQL executed against golden copies
+    verify(db).insertReturningPk(eq("insert into dbtest (data_id, name, local_date, update_sequence, update_time) values (nextval('id_seq'),?,?,0,?)"), anyString());
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testFindByColumnOrder() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("name", "local_date", "update_sequence", "update_time")
+      .addRow("Foo", localDateNow, 3, now));
+
+    // The test scenario
+    RowStubMockData data = rowStubMockDao.findById(12L, RowStubMockDao.ColumnLookupType.BY_ORDER, false);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(12L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(3), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).query(anyString(), eq("select name, local_date, update_sequence, update_time from dbtest where data_id=12"));
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testFindByColumnNames() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("name", "local_date", "update_sequence", "update_time")
+      .addRow("Foo", localDateNow, 3, now));
+
+    // The test scenario
+    RowStubMockData data = rowStubMockDao.findById(13L, RowStubMockDao.ColumnLookupType.BY_NAME, false);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(13L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(3), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).query(anyString(), eq("select name, local_date, update_sequence, update_time from dbtest where data_id=13"));
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testFindAndLock() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("name", "local_date", "update_sequence", "update_time")
+      .addRow("Foo", localDateNow, 3, now));
+
+    // The test scenario
+    RowStubMockData data = rowStubMockDao.findById(15L, RowStubMockDao.ColumnLookupType.BY_NUMBER, true);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(15L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(3), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).query(anyString(), eq("select name, local_date, update_sequence, update_time from dbtest where data_id=15 for update"));
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testUpdate() throws Exception {
+    // Configure the mock because our class under test expects values to be returned from the db
+    when(db.query(anyString(), anyString())).thenReturn(new RowStub()
+      .withColumnNames("name", "local_date", "update_sequence", "update_time")
+      .addRow("Foo", localDateNow, 3, now));
+    Date before = new Date(now.getTime() - 5000);
+
+    RowStubMockData data = new RowStubMockData();
+    data.setDataId(100L);
+    data.setName("Foo");
+    data.setLocalDate(localDateNow);
+    data.setUpdateSequence(13);
+    data.setUpdateTime(before);
+    rowStubMockDao.update(data, 23L);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(100L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(localDateNow, data.getLocalDate());
+    assertEquals(new Integer(14), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).update(eq("update dbtest set name=?, local_date=?, update_sequence=?, update_time=? where data_id=?"), anyString());
+    verifyNoMoreInteractions(db);
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Date before = new Date(now.getTime() - 5000);
+
+    RowStubMockData data = new RowStubMockData();
+    data.setDataId(100L);
+    data.setName("Foo");
+    data.setUpdateSequence(13);
+    data.setUpdateTime(before);
+    rowStubMockDao.delete(data, 23L);
+
+    // Verify object in memory is updated properly
+    assertEquals(new Long(100L), data.getDataId());
+    assertEquals("Foo", data.getName());
+    assertEquals(new Integer(14), data.getUpdateSequence());
+    assertEquals(now, data.getUpdateTime());
+
+    // Verify database queries against golden copies
+    verify(db).update(anyString(), eq("delete from dbtest where data_id=100"));
+    verifyNoMoreInteractions(db);
+  }
+}


### PR DESCRIPTION
The original branch for the SuSoM database LocalDate framework feature became a mess due to both many reviews and a bad merge that I did.  Rolling that back and cleaning it up would be non-trivial.  I created a clean branch and applied the changes on there in hopes that will be OK for review before merging down.  Along the way, I also did minor clean up of things I spotted that would have been hard to spot with the previous fairly complex review path.  

Garrick - can you take a look and advise if this is OK?   