### PR TITLE
STRIDE-505 Fix handling of Oracle character fields

### DIFF
--- a/src/main/java/com/github/susom/database/Flavor.java
+++ b/src/main/java/com/github/susom/database/Flavor.java
@@ -335,7 +335,7 @@ public enum Flavor {
 
     @Override
     public String typeBoolean() {
-      return "char(1)";
+      return "char(1 char)";
     }
 
     @Override

--- a/src/main/java/com/github/susom/database/Flavor.java
+++ b/src/main/java/com/github/susom/database/Flavor.java
@@ -66,13 +66,13 @@ public enum Flavor {
     }
 
     @Override
-    public String typeStringVar(int bytes) {
-      return "varchar(" + bytes + ")";
+    public String typeStringVar(int length) {
+      return "varchar(" + length + ")";
     }
 
     @Override
-    public String typeStringFixed(int bytes) {
-      return "char(" + bytes + ")";
+    public String typeStringFixed(int length) {
+      return "char(" + length + ")";
     }
 
     @Override
@@ -239,13 +239,13 @@ public enum Flavor {
     }
 
     @Override
-    public String typeStringVar(int bytes) {
-      return "varchar(" + bytes + ")";
+    public String typeStringVar(int length) {
+      return "varchar(" + length + ")";
     }
 
     @Override
-    public String typeStringFixed(int bytes) {
-      return "char(" + bytes + ")";
+    public String typeStringFixed(int length) {
+      return "char(" + length + ")";
     }
 
     @Override
@@ -379,13 +379,13 @@ public enum Flavor {
     }
 
     @Override
-    public String typeStringVar(int bytes) {
-      return "varchar2(" + bytes + ")";
+    public String typeStringVar(int length) {
+      return "varchar2(" + length + " char)";
     }
 
     @Override
-    public String typeStringFixed(int bytes) {
-      return "char(" + bytes + ")";
+    public String typeStringFixed(int length) {
+      return "char(" + length + " char)";
     }
 
     @Override
@@ -482,13 +482,13 @@ public enum Flavor {
     }
 
     @Override
-    public String typeStringVar(int bytes) {
-      return "varchar(" + bytes + ")";
+    public String typeStringVar(int length) {
+      return "varchar(" + length + ")";
     }
 
     @Override
-    public String typeStringFixed(int bytes) {
-      return "char(" + bytes + ")";
+    public String typeStringFixed(int length) {
+      return "char(" + length + ")";
     }
 
     @Override
@@ -619,13 +619,13 @@ public enum Flavor {
     }
 
     @Override
-    public String typeStringVar(int bytes) {
-      return "varchar(" + bytes + ")";
+    public String typeStringVar(int length) {
+      return "varchar(" + length + ")";
     }
 
     @Override
-    public String typeStringFixed(int bytes) {
-      return "char(" + bytes + ")";
+    public String typeStringFixed(int length) {
+      return "char(" + length + ")";
     }
 
     @Override
@@ -737,9 +737,9 @@ public enum Flavor {
 
   public abstract String typeBigDecimal(int size, int precision);
 
-  public abstract String typeStringVar(int bytes);
+  public abstract String typeStringVar(int length);
 
-  public abstract String typeStringFixed(int bytes);
+  public abstract String typeStringFixed(int length);
 
   public abstract String typeClob();
 


### PR DESCRIPTION
Oracle has a non-standard interpretation of character field lengths.  The SQL standard and other implementations says that the length of a character field is in characters unless explicitly specified to be in bytes.  Oracle does it the other way around (of course).  This means that the library's `Schema::addTableFromRow` method, if the source row comes from a non-Oracle database and the destination is an Oracle database, can produce a table with columns that are not wide enough (when multi-byte characters are involved).

This change makes the Oracle flavor specify that character lengths are in characters.