### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
           <includes>
             <include>%regex[.*(Config|Database|Derby|RowStub|SqlArgs|VertxLogging|Demo|SampleDao)Test.*]</include>
           </includes>
+        	<forkCount>1.5C</forkCount>
         </configuration>
       </plugin>
       <plugin>
@@ -392,6 +393,7 @@
               <includes combine.children="append">
                 <include>**/*Oracle*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>
@@ -416,6 +418,7 @@
               <includes combine.children="append">
                 <include>**/*Oracle*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>
@@ -440,6 +443,7 @@
               <includes combine.children="append">
                 <include>**/*Oracle*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>
@@ -464,6 +468,7 @@
               <includes combine.children="append">
                 <include>**/*Oracle*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>
@@ -488,6 +493,7 @@
               <includes>
                 <include>**/*Oracle*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>
@@ -512,6 +518,7 @@
               <includes combine.children="append">
                 <include>**/*SqlServer*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>
@@ -536,6 +543,7 @@
               <includes>
                 <include>**/*SqlServer*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>
@@ -560,6 +568,7 @@
               <includes combine.children="append">
                 <include>**/*Hsqldb*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>
@@ -584,6 +593,7 @@
               <includes combine.children="append">
                 <include>**/*PostgreSql*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>
@@ -608,6 +618,7 @@
               <includes>
                 <include>**/*PostgreSql*</include>
               </includes>
+        	<forkCount>1.5C</forkCount>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
