### PR TITLE
Added 'database.conn.initsql' option for config

### DIFF
--- a/src/main/java/com/github/susom/database/DatabaseProvider.java
+++ b/src/main/java/com/github/susom/database/DatabaseProvider.java
@@ -1139,6 +1139,7 @@ public final class DatabaseProvider implements Supplier<Database> {
     int poolSize = config.getInteger("database.pool.size", 10);
     ds.setMaximumPoolSize(poolSize);
     ds.setAutoCommit(false);
+    ds.setConnectionInitSql(config.getString("database.conn.initsql"));
 
     Flavor flavor;
     String flavorString = config.getString("database.flavor");


### PR DESCRIPTION
New config property `database.conn.initsql`. This was needed by db-to-avro so we could could use 'alter session' statements. 

Null [appears to be OK](https://github.com/brettwooldridge/HikariCP/blob/2e07be7b325b05f7225611c60f421e253e1107a5/src/main/java/com/zaxxer/hikari/HikariConfig.java#L998) as a default value.

