### PR TITLE
Fix Travis docker postgres

### DIFF
--- a/test-postgres.sh
+++ b/test-postgres.sh
@@ -41,6 +41,6 @@ run_pg_tests() {
 run_pg_tests 9.6
 run_pg_tests 10
 run_pg_tests 11
-run_pg_tests 12
-run_pg_tests 13
-run_pg_tests 14
+run_pg_tests 12-bullseye
+run_pg_tests 13-bullseye
+run_pg_tests 14-bullseye


### PR DESCRIPTION
New "bookworm" variant of postgres docker images recently became default, doesn't work on Travis for some reason, use the previous "bullseye" variant instead.

Not worth my time to figure out why this presumably known-good docker image doesn't work on Travis.
